### PR TITLE
ci: enable gitlint

### DIFF
--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -1,0 +1,20 @@
+name: Lint Git Commits 
+
+on:
+  pull_request: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Install GitLint
+        run: pip install gitlint
+
+      - name: Run GitLint 
+        run: gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD"

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,9 @@
+[general]
+contrib=contrib-body-requires-signed-off-by,contrib-disallow-cleanup-commits
+ignore-merge-commits=false
+ignore-fixup-commits=false
+ignore-fixup-amend-commits=false
+ignore-squash-commits=false
+
+[title-match-regex]
+regex=[a-z0-9/]+: .*


### PR DESCRIPTION
Applied rules:

- Built-in rulles: all defaults, except:

  - Do not ignore cleanup commits (conflicts with CC2)
  - Do not ignore merge commits (they will fail with the rule below)
  - Custom title regex, enforce `area[/subarea]: description`, e.g. `docs: add new GSG guide`, `drivers/qspi: fix quad-line access`, etc.

- Contrib rules:

  - CC1: require Signed-off-by (DCO)
  - CC2: no cleanup commits (fixup!, squash!, amend!)

Ref. https://jorisroovers.com/gitlint/latest/rules/