### PR TITLE
tools: fix bug where SVG paths with only move commands cause crash

### DIFF
--- a/tools/generate_pdcs/pebble_commands.py
+++ b/tools/generate_pdcs/pebble_commands.py
@@ -184,6 +184,7 @@ class PathCommand(Command):
         self.type = DRAW_COMMAND_TYPE_PATH if not precise else DRAW_COMMAND_TYPE_PRECISE_PATH
         Command.__init__(self, points, translate, stroke_width, stroke_color, fill_color, verbose,
                          precise, raise_error)
+        assert(len(points) >= 1)
 
     def serialize(self):
         s = pack('B', self.type)   # command type

--- a/tools/generate_pdcs/svg2commands.py
+++ b/tools/generate_pdcs/svg2commands.py
@@ -96,7 +96,8 @@ def parse_path(element, translate, stroke_width, stroke_color, fill_color, verbo
     if d is not None:
         path = svg.path.parse_path(d)
         points = [(lambda l: (l.real, l.imag))(line.start) for line in path]
-        if not points:
+        move_commands_only = len([line for line in path if isinstance(line, svg.path.Move)]) == len(path)
+        if not points or move_commands_only:
             print("No points in parsed path")
             return None
 


### PR DESCRIPTION
A path like "M5.8,9.1" resulted in a PDC with no points which causes an assert at runtime (eg when scrolling down the launcher to the Workout app). Filtering these out at build time avoids this.

I rendered the SVG with these rows removed and it doesn't appear to make a difference, but I'm not entirely confident in this fix even still...