### PR TITLE
submodule: update STM32 SDK URL to use HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/ARM-software/CMSIS_5.git
 [submodule "src/fw/vendor/stm32-sdk"]
 	path = src/fw/vendor/stm32-sdk
-	url = git@github.com:pebble-dev/stm32-sdk.git
+	url = https://github.com/pebble-dev/stm32-sdk.git


### PR DESCRIPTION
This pull request includes a small change to the `.gitmodules` file. The change updates the URL of the `stm32-sdk` submodule to use HTTPS instead of SSH.
Switching to HTTPS ensures that all contributors, regardless of their SSH configuration or familiarity, can easily clone and work with the repository.