### PR TITLE
tools: make pulse tools work for bigboards with public pyftdi

### DIFF
--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -2,7 +2,7 @@
 Pillow
 freetype-py
 ply==3.4
-pyusb==1.0.0b2
+pyusb==1.3.1
 pyserial
 sh==1.04
 pypng
@@ -34,5 +34,5 @@ packaging
 #pebble.programmer>=0.0.4
 #pebble.commander==0.0.11
 libpebble2>=0.0.16
-pyftdi==0.13.4
+pyftdi==0.56.0
 pathlib

--- a/tools/pebble_ftdi_custom_pids.py
+++ b/tools/pebble_ftdi_custom_pids.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyftdi.ftdi import Ftdi
+from pyftdi.misc import add_custom_devices
+
+def configure_pids():
+    add_custom_devices(Ftdi, ["ftdi=0x403:silk=0x7893", "ftdi=0x403:robert=0x7898"], force_hex = True)

--- a/tools/pulse_console.py
+++ b/tools/pulse_console.py
@@ -23,6 +23,8 @@ import sys
 from pebble import pulse2, commander
 from log_hashing.logdehash import LogDehash
 
+import pebble_ftdi_custom_pids
+pebble_ftdi_custom_pids.configure_pids()
 
 PROMPT_STRING = '> '
 

--- a/tools/pulse_flash_imaging.py
+++ b/tools/pulse_flash_imaging.py
@@ -24,6 +24,8 @@ from pebble import pulse2, commander
 
 from pebble.commander._commands.imaging import load_firmware, load_resources
 
+import pebble_ftdi_custom_pids
+pebble_ftdi_custom_pids.configure_pids()
 
 class FakeCommander(object):
     def __init__(self, flash):


### PR DESCRIPTION
This is slightly awkward because you have to setup the custom PID, so any tool that needs those boards supported has to import and call that function.