### PR TITLE
tools: fix readelf parsing with more than 100 sections

### DIFF
--- a/sdk/tools/inject_metadata.py
+++ b/sdk/tools/inject_metadata.py
@@ -145,9 +145,10 @@ def inject_metadata(target_binary, target_elf, resources_file, timestamp, allow_
                 continue
 
             # Carve off the first column, since it sometimes has a space in it which screws up the
-            # split. Two leading spaces, a square bracket, 2 digits (with space padding),
-            # a second square brack is 6
-            line = line[6:]
+            # split.
+            if not ']' in line:
+                continue
+            line = line[line.index(']') + 1:]
 
             columns = line.split()
             if len(columns) < 6:


### PR DESCRIPTION
This fixes readelf parsing for SDK builds when an ELF has more than 100 sections. I encountered this years ago when trying to get Rust to work on the Pebble: https://github.com/pebble-rust/pebble-rust/blob/master/docs/TROUBLESHOOTING.md

See also: https://github.com/coredevices/pebble/pull/3