### PR TITLE
WIP: Add BannerTitles to Notifications (BetterNotifications)

### DIFF
--- a/src/fw/applib/graphics/gdraw_command_image.c
+++ b/src/fw/applib/graphics/gdraw_command_image.c
@@ -140,3 +140,36 @@ GDrawCommandList *gdraw_command_image_get_command_list(GDrawCommandImage *image)
 
   return &image->command_list;
 }
+
+#if PBL_BW
+// These functions are only needed for B&W platforms due to the new notification system
+void gdraw_command_image_set_stroke_color(GDrawCommandImage *image, GColor stroke_color) {
+  if (!image) {
+    return;
+  }
+
+  GDrawCommandList *command_list = gdraw_command_image_get_command_list(image);
+  if (command_list) {
+    GDrawCommand *command = command_list->commands;
+    for (uint32_t j = 0; j < command_list->num_commands; j++) {
+      gdraw_command_set_stroke_color(command, stroke_color);
+      command = (GDrawCommand *) (command->points + command->num_points);
+    }
+  }
+}
+
+void gdraw_command_image_set_fill_color(GDrawCommandImage *image, GColor fill_color) {
+  if (!image) {
+    return;
+  }
+
+  GDrawCommandList *command_list = gdraw_command_image_get_command_list(image);
+  if (command_list) {
+    GDrawCommand *command = command_list->commands;
+    for (uint32_t j = 0; j < command_list->num_commands; j++) {
+      gdraw_command_set_fill_color(command, fill_color);
+      command = (GDrawCommand *) (command->points + command->num_points);
+    }
+  }
+}
+#endif

--- a/src/fw/applib/graphics/gdraw_command_image.h
+++ b/src/fw/applib/graphics/gdraw_command_image.h
@@ -103,5 +103,17 @@ void gdraw_command_image_set_bounds_size(GDrawCommandImage *image, GSize size);
 //! @return command list
 GDrawCommandList *gdraw_command_image_get_command_list(GDrawCommandImage *image);
 
+#if PBL_BW
+//! Sets the stroke color for all commands in the image.
+//! @param image The image to modify.
+//! @param stroke_color The new stroke color.
+void gdraw_command_image_set_stroke_color(GDrawCommandImage *image, GColor stroke_color);
+
+//! Sets the fill color for all commands in the image.
+//! @param image The image to modify.
+//! @param fill_color The new fill color.
+void gdraw_command_image_set_fill_color(GDrawCommandImage *image, GColor fill_color);
+#endif
+
 //!   @} // end addtogroup DrawCommand
 //! @} // end addtogroup Graphics

--- a/src/fw/applib/graphics/gdraw_command_sequence.c
+++ b/src/fw/applib/graphics/gdraw_command_sequence.c
@@ -214,3 +214,44 @@ uint32_t gdraw_command_sequence_get_num_frames(GDrawCommandSequence *sequence) {
 
   return sequence->num_frames;
 }
+
+#if PBL_BW
+// These functions are only needed for B&W platforms due to the new notification system
+void gdraw_command_sequence_set_stroke_color(GDrawCommandSequence *sequence, GColor stroke_color) {
+  if (!sequence) {
+    return;
+  }
+
+  GDrawCommandFrame *frame = sequence->frames;
+  for (uint32_t i = 0; i < sequence->num_frames; i++) {
+    GDrawCommandList *command_list = gdraw_command_frame_get_command_list(frame);
+    if (command_list) {
+      GDrawCommand *command = command_list->commands;
+      for (uint32_t j = 0; j < command_list->num_commands; j++) {
+        gdraw_command_set_stroke_color(command, stroke_color);
+        command = (GDrawCommand *) (command->points + command->num_points);
+      }
+    }
+    frame = prv_next_frame(frame);
+  }
+}
+
+void gdraw_command_sequence_set_fill_color(GDrawCommandSequence *sequence, GColor fill_color) {
+  if (!sequence) {
+    return;
+  }
+
+  GDrawCommandFrame *frame = sequence->frames;
+  for (uint32_t i = 0; i < sequence->num_frames; i++) {
+    GDrawCommandList *command_list = gdraw_command_frame_get_command_list(frame);
+    if (command_list) {
+      GDrawCommand *command = command_list->commands;
+      for (uint32_t j = 0; j < command_list->num_commands; j++) {
+        gdraw_command_set_fill_color(command, fill_color);
+        command = (GDrawCommand *) (command->points + command->num_points);
+      }
+    }
+    frame = prv_next_frame(frame);
+  }
+}
+#endif

--- a/src/fw/applib/graphics/gdraw_command_sequence.h
+++ b/src/fw/applib/graphics/gdraw_command_sequence.h
@@ -114,5 +114,17 @@ uint32_t gdraw_command_sequence_get_total_duration(GDrawCommandSequence *sequenc
 //! @return number of frames in the sequence
 uint32_t gdraw_command_sequence_get_num_frames(GDrawCommandSequence *sequence);
 
+#if PBL_BW
+//! Sets the stroke color for all commands in the sequence.
+//! @param sequence The sequence to modify.
+//! @param stroke_color The new stroke color.
+void gdraw_command_sequence_set_stroke_color(GDrawCommandSequence *sequence, GColor stroke_color);
+
+//! Sets the fill color for all commands in the sequence.
+//! @param sequence The sequence to modify.
+//! @param fill_color The new fill color.
+void gdraw_command_sequence_set_fill_color(GDrawCommandSequence *sequence, GColor fill_color);
+#endif
+
 //!   @} // end addtogroup DrawCommand
 //! @} // end addtogroup Graphics

--- a/src/fw/applib/ui/kino/kino_layer.c
+++ b/src/fw/applib/ui/kino/kino_layer.c
@@ -112,8 +112,8 @@ void kino_layer_set_reel_with_resource(KinoLayer *kino_layer, uint32_t resource_
 }
 
 void kino_layer_set_reel_with_resource_system(KinoLayer *kino_layer, ResAppNum app_num,
-                                              uint32_t resource_id) {
-  kino_player_set_reel_with_resource_system(&kino_layer->player, app_num, resource_id);
+                                              uint32_t resource_id, bool invert) {
+  kino_player_set_reel_with_resource_system(&kino_layer->player, app_num, resource_id, invert);
 }
 
 KinoReel *kino_layer_get_reel(KinoLayer *kino_layer) {

--- a/src/fw/applib/ui/kino/kino_layer.h
+++ b/src/fw/applib/ui/kino/kino_layer.h
@@ -54,7 +54,7 @@ void kino_layer_set_reel(KinoLayer *kino_layer, KinoReel *reel, bool take_owners
 //! @internal
 void kino_layer_set_reel_with_resource(KinoLayer *kino_layer, uint32_t resource_id);
 void kino_layer_set_reel_with_resource_system(KinoLayer *kino_layer, ResAppNum app_num,
-                                              uint32_t resource_id);
+                                              uint32_t resource_id, bool invert);
 
 KinoReel *kino_layer_get_reel(KinoLayer *kino_layer);
 

--- a/src/fw/applib/ui/kino/kino_player.c
+++ b/src/fw/applib/ui/kino/kino_player.c
@@ -123,9 +123,9 @@ void kino_player_set_reel_with_resource(KinoPlayer *player, uint32_t resource_id
 }
 
 void kino_player_set_reel_with_resource_system(KinoPlayer *player, ResAppNum app_num,
-                                               uint32_t resource_id) {
+                                               uint32_t resource_id, bool invert) {
   kino_player_set_reel(player, NULL, false);
-  KinoReel *new_reel = kino_reel_create_with_resource_system(app_num, resource_id);
+  KinoReel *new_reel = kino_reel_create_with_resource_system_with_invert(app_num, resource_id, invert);
   kino_player_set_reel(player, new_reel, true);
 }
 

--- a/src/fw/applib/ui/kino/kino_player.h
+++ b/src/fw/applib/ui/kino/kino_player.h
@@ -48,7 +48,7 @@ void kino_player_set_reel(KinoPlayer *player, KinoReel *reel, bool take_ownershi
 //! @internal
 void kino_player_set_reel_with_resource(KinoPlayer *player, uint32_t resource_id);
 void kino_player_set_reel_with_resource_system(KinoPlayer *player, ResAppNum app_num,
-                                               uint32_t resource_id);
+                                               uint32_t resource_id, bool invert);
 
 KinoReel *kino_player_get_reel(KinoPlayer *player);
 

--- a/src/fw/applib/ui/kino/kino_reel.c
+++ b/src/fw/applib/ui/kino/kino_reel.c
@@ -37,6 +37,10 @@ KinoReel *kino_reel_create_with_resource(uint32_t resource_id) {
 }
 
 KinoReel *kino_reel_create_with_resource_system(ResAppNum app_num, uint32_t resource_id) {
+  return kino_reel_create_with_resource_system_with_invert(app_num, resource_id, false);
+}
+
+KinoReel *kino_reel_create_with_resource_system_with_invert(ResAppNum app_num, uint32_t resource_id, bool invert) {
   if (resource_id == RESOURCE_ID_INVALID) {
     return NULL;
   }
@@ -50,9 +54,9 @@ KinoReel *kino_reel_create_with_resource_system(ResAppNum app_num, uint32_t reso
 
   switch (ntohl(data_signature)) {
     case PDCS_SIGNATURE:
-      return kino_reel_pdcs_create_with_resource_system(app_num, resource_id);
+      return kino_reel_pdcs_create_with_resource_system(app_num, resource_id, invert);
     case PDCI_SIGNATURE:
-      return kino_reel_pdci_create_with_resource_system(app_num, resource_id);
+      return kino_reel_pdci_create_with_resource_system(app_num, resource_id, invert);
     case PNG_SIGNATURE:
       {
         bool is_apng = false;

--- a/src/fw/applib/ui/kino/kino_reel.h
+++ b/src/fw/applib/ui/kino/kino_reel.h
@@ -86,9 +86,11 @@ struct KinoReel {
   const KinoReelImpl *impl;
 };
 
-KinoReel *kino_reel_create_with_resource(uint32_t resource_id);
+KinoReel *kino_reel_create_with_resource(uint32_t resource_id);\
 
 KinoReel *kino_reel_create_with_resource_system(ResAppNum app_num, uint32_t resource_id);
+
+KinoReel *kino_reel_create_with_resource_system_with_invert(ResAppNum app_num, uint32_t resource_id, bool invert);
 
 void kino_reel_destroy(KinoReel *reel);
 

--- a/src/fw/applib/ui/kino/kino_reel_pdci.c
+++ b/src/fw/applib/ui/kino/kino_reel_pdci.c
@@ -90,13 +90,19 @@ KinoReel *kino_reel_pdci_create(GDrawCommandImage *image, bool take_ownership) {
 
 KinoReel *kino_reel_pdci_create_with_resource(uint32_t resource_id) {
   ResAppNum app_num = sys_get_current_resource_num();
-  return kino_reel_pdci_create_with_resource_system(app_num, resource_id);
+  return kino_reel_pdci_create_with_resource_system(app_num, resource_id, false);
 }
 
-KinoReel *kino_reel_pdci_create_with_resource_system(ResAppNum app_num, uint32_t resource_id) {
+KinoReel *kino_reel_pdci_create_with_resource_system(ResAppNum app_num, uint32_t resource_id, bool invert) {
   GDrawCommandImage *image = gdraw_command_image_create_with_resource_system(app_num, resource_id);
   if (image == NULL) {
     return NULL;
   }
+  #if PBL_BW
+    if (invert) {
+      gdraw_command_image_set_stroke_color(image, GColorWhite);
+      gdraw_command_image_set_fill_color(image, GColorBlack);
+    }
+  #endif
   return kino_reel_pdci_create(image, true);
 }

--- a/src/fw/applib/ui/kino/kino_reel_pdci.h
+++ b/src/fw/applib/ui/kino/kino_reel_pdci.h
@@ -22,4 +22,4 @@ KinoReel *kino_reel_pdci_create(GDrawCommandImage *image, bool take_ownership);
 
 KinoReel *kino_reel_pdci_create_with_resource(uint32_t resource_id);
 
-KinoReel *kino_reel_pdci_create_with_resource_system(ResAppNum app_num, uint32_t resource_id);
+KinoReel *kino_reel_pdci_create_with_resource_system(ResAppNum app_num, uint32_t resource_id, bool invert);

--- a/src/fw/applib/ui/kino/kino_reel_pdcs.c
+++ b/src/fw/applib/ui/kino/kino_reel_pdcs.c
@@ -133,14 +133,20 @@ KinoReel *kino_reel_pdcs_create(GDrawCommandSequence *sequence, bool take_owners
 
 KinoReel *kino_reel_pdcs_create_with_resource(uint32_t resource_id) {
   ResAppNum app_num = sys_get_current_resource_num();
-  return kino_reel_pdcs_create_with_resource_system(app_num, resource_id);
+  return kino_reel_pdcs_create_with_resource_system(app_num, resource_id, false);
 }
 
-KinoReel *kino_reel_pdcs_create_with_resource_system(ResAppNum app_num, uint32_t resource_id) {
+KinoReel *kino_reel_pdcs_create_with_resource_system(ResAppNum app_num, uint32_t resource_id, bool invert) {
   GDrawCommandSequence *sequence = gdraw_command_sequence_create_with_resource_system(app_num,
                                                                                       resource_id);
   if (sequence == NULL) {
     return NULL;
   }
+  #if PBL_BW
+    if (invert) {
+      gdraw_command_sequence_set_stroke_color(sequence, GColorWhite);
+      gdraw_command_sequence_set_fill_color(sequence, GColorBlack);
+    }
+  #endif
   return kino_reel_pdcs_create(sequence, true);
 }

--- a/src/fw/applib/ui/kino/kino_reel_pdcs.h
+++ b/src/fw/applib/ui/kino/kino_reel_pdcs.h
@@ -22,4 +22,4 @@ KinoReel *kino_reel_pdcs_create(GDrawCommandSequence *sequence, bool take_owners
 
 KinoReel *kino_reel_pdcs_create_with_resource(uint32_t resource_id);
 
-KinoReel *kino_reel_pdcs_create_with_resource_system(ResAppNum app_num, uint32_t resource_id);
+KinoReel *kino_reel_pdcs_create_with_resource_system(ResAppNum app_num, uint32_t resource_id, bool invert);

--- a/src/fw/apps/system_apps/timeline/peek_layer.c
+++ b/src/fw/apps/system_apps/timeline/peek_layer.c
@@ -187,12 +187,17 @@ static bool prv_is_dot_size(GSize size) {
 
 void peek_layer_set_icon_with_size(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
                                    TimelineResourceSize res_size, GRect icon_from) {
+  peek_layer_set_icon_with_size_with_invert(peek_layer, timeline_res, res_size, icon_from, false);
+}
+
+void peek_layer_set_icon_with_size_with_invert(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
+                                   TimelineResourceSize res_size, GRect icon_from, bool invert) {
   kino_layer_set_reel(&peek_layer->kino_layer, NULL, false);
 
   AppResourceInfo icon_res_info;
   timeline_resources_get_id(timeline_res, res_size, &icon_res_info);
-  KinoReel *from_reel = kino_reel_create_with_resource_system(icon_res_info.res_app_num,
-                                                              icon_res_info.res_id);
+  KinoReel *from_reel = kino_reel_create_with_resource_system_with_invert(icon_res_info.res_app_num,
+                                                              icon_res_info.res_id, invert);
   if (!from_reel) {
     return;
   }
@@ -239,6 +244,10 @@ void peek_layer_set_icon(PeekLayer *peek_layer, const TimelineResourceInfo *time
   peek_layer_set_icon_with_size(peek_layer, timeline_res, TimelineResourceSizeLarge, GRectZero);
 }
 
+void peek_layer_set_icon_with_invert(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res, bool invert) {
+  peek_layer_set_icon_with_size_with_invert(peek_layer, timeline_res, TimelineResourceSizeLarge, GRectZero, invert);
+}
+
 //! This is called after both the scale to and the PDCS is complete
 static void prv_scale_to_did_stop(KinoLayer *kino_layer, bool finished, void *context) {
   PeekLayer *peek_layer = context;
@@ -258,6 +267,13 @@ static void prv_scale_to_timer_callback(void *data) {
 void peek_layer_set_scale_to_image(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
                                    TimelineResourceSize res_size, GRect icon_to,
                                    bool align_in_frame) {
+  peek_layer_set_scale_to_image_with_invert(peek_layer, timeline_res, res_size, icon_to,
+                                            align_in_frame, false);
+}
+
+void peek_layer_set_scale_to_image_with_invert(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
+                                   TimelineResourceSize res_size, GRect icon_to,
+                                   bool align_in_frame, bool invert) {
   GRect icon_from = GRectZero;
   KinoReel *prev_reel = kino_layer_get_reel(&peek_layer->kino_layer);
   if (prev_reel) {
@@ -266,8 +282,8 @@ void peek_layer_set_scale_to_image(PeekLayer *peek_layer, const TimelineResource
   }
   kino_layer_set_reel(&peek_layer->kino_layer, NULL, false);
 
-  KinoReel *from_reel = kino_reel_create_with_resource_system(peek_layer->res_info.res_app_num,
-                                                              peek_layer->res_info.res_id);
+  KinoReel *from_reel = kino_reel_create_with_resource_system_with_invert(peek_layer->res_info.res_app_num,
+                                                              peek_layer->res_info.res_id, invert);
   if (!from_reel) {
     return;
   }
@@ -276,8 +292,8 @@ void peek_layer_set_scale_to_image(PeekLayer *peek_layer, const TimelineResource
   if (timeline_res) {
     AppResourceInfo res_info;
     timeline_resources_get_id(timeline_res, res_size, &res_info);
-    to_reel = kino_reel_create_with_resource_system(res_info.res_app_num,
-                                                    res_info.res_id);
+    to_reel = kino_reel_create_with_resource_system_with_invert(res_info.res_app_num,
+                                                    res_info.res_id, invert);
   }
 
   GSize size;

--- a/src/fw/apps/system_apps/timeline/peek_layer.h
+++ b/src/fw/apps/system_apps/timeline/peek_layer.h
@@ -79,8 +79,11 @@ void peek_layer_set_frame(PeekLayer *peek_layer, const GRect *frame);
 //! The peek layer will be primed with an unfold animation.
 //! The resource will begin as a dot until the peek layer is played.
 void peek_layer_set_icon(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res);
+void peek_layer_set_icon_with_invert(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res, bool invert);
 void peek_layer_set_icon_with_size(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
                                    TimelineResourceSize res_size, GRect icon_from);
+void peek_layer_set_icon_with_size_with_invert(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
+                                   TimelineResourceSize res_size, GRect icon_from, bool invert);
 
 //! Set the peek layer to have a stretching animation to a frame.
 //! @param align_in_frame if true, scale the image to the resource size and align within icon_to
@@ -89,6 +92,15 @@ void peek_layer_set_scale_to(PeekLayer *peek_layer, GRect icon_to);
 void peek_layer_set_scale_to_image(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
                                    TimelineResourceSize res_size, GRect icon_to,
                                    bool align_in_frame);
+
+//! Set the peek layer to have a stretching animation to a frame with the ability to invert the icon.
+//! @param align_in_frame if true, scale the image to the resource size and align within icon_to
+//! @param invert if true, invert the icon
+//! instead of scaling to the icon_to size
+void peek_layer_set_scale_to(PeekLayer *peek_layer, GRect icon_to);
+void peek_layer_set_scale_to_image_with_invert(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
+                                   TimelineResourceSize res_size, GRect icon_to,
+                                   bool align_in_frame, bool invert);
 
 //! Set the duration of the primed animation in milliseconds.
 void peek_layer_set_duration(PeekLayer *peek_layer, uint32_t duration);

--- a/src/fw/popups/notifications/notification_window_private.h
+++ b/src/fw/popups/notifications/notification_window_private.h
@@ -61,4 +61,6 @@ typedef struct NotificationWindowData {
   Layer dnd_icon_layer;
   GBitmap dnd_icon;
   bool dnd_icon_visible;
+
+  TextLayer *banner_title_layer;
 } NotificationWindowData;

--- a/src/fw/services/normal/timeline/attribute.c
+++ b/src/fw/services/normal/timeline/attribute.c
@@ -69,6 +69,7 @@ static AttributeType prv_attribute_type(AttributeId id) {
     case AttributeIdAddress:
     case AttributeIdAuthCode:
     case AttributeIdSubtitleTemplateString:
+    case AttributeIdBannerTitle:
       return AttributeTypeString;
     case AttributeIdAncsAction:
     case AttributeIdSportsGameState:

--- a/src/fw/services/normal/timeline/attribute.h
+++ b/src/fw/services/normal/timeline/attribute.h
@@ -124,6 +124,8 @@ typedef enum {
   AttributeIdSubtitleTemplateString = 47,
   //! Generic icon.
   AttributeIdIcon = 48,
+  //! Origin of a Notification, will be displayed in the banner.
+  AttributeIdBannerTitle = 49,
   NumAttributeIds,
 } AttributeId;
 

--- a/src/fw/services/normal/timeline/layout_layer.c
+++ b/src/fw/services/normal/timeline/layout_layer.c
@@ -57,9 +57,9 @@ static const LayoutColors s_default_colors = {
 };
 
 static const LayoutColors s_default_notification_colors = {
-  .primary_color = { .argb = GColorBlackARGB8 },
+  .primary_color = { .argb = GColorWhiteARGB8 },
   .secondary_color = { .argb = GColorBlackARGB8 },
-  .bg_color = { .argb = GColorLightGrayARGB8 },
+  .bg_color = { .argb = GColorBlackARGB8 },
 };
 
 LayoutLayer *layout_create(LayoutId id, const LayoutLayerConfig *config) {

--- a/src/fw/services/normal/timeline/notification_layout.h
+++ b/src/fw/services/normal/timeline/notification_layout.h
@@ -25,6 +25,7 @@
 #include "applib/graphics/perimeter.h"
 #include "applib/ui/bitmap_layer.h"
 #include "applib/ui/kino/kino_layer.h"
+#include "applib/ui/text_layer.h"
 #include "services/normal/timeline/attribute.h"
 #include "services/normal/timeline/timeline_resources.h"
 
@@ -99,6 +100,8 @@ typedef struct {
 #endif
 } NotificationLayoutInfo;
 
+typedef struct BannerScrollState BannerScrollState;
+
 typedef struct {
   LayoutLayer layout;
   KinoLayer icon_layer;
@@ -111,7 +114,14 @@ typedef struct {
   const NotificationStyle *style;
   GTextNode *view_node;
   GSize view_size;
+  TextLayer *banner_title_layer;
+  int banner_scroll_cycle;           // Track scroll cycle count
+  AppTimer *banner_scroll_timer;     // Timer for scrolling
+  int16_t banner_title_scroll_distance; // Distance to scroll
+  bool destroyed;
+  uint8_t banner_scroll_state;
 } NotificationLayout;
+
 
 //! Default notification color
 #define DEFAULT_NOTIFICATION_COLOR (GColorFolly)

--- a/src/fw/services/normal/timeline/swap_layer.c
+++ b/src/fw/services/normal/timeline/swap_layer.c
@@ -248,15 +248,10 @@ static void prv_arrow_layer_update_proc(Layer *layer, GContext* ctx) {
 
   const GRect *layer_bounds = &layer->bounds;
 
-#if PBL_RECT
-  graphics_context_set_fill_color(ctx, GColorWhite);
-  graphics_fill_rect(ctx, layer_bounds);
-#endif
-
   GRect arrow_bounds = arrow_layer->arrow_bitmap.bounds;
-  const GAlign arrow_alignment = PBL_IF_RECT_ELSE(GAlignTop, GAlignBottom);
+  const GAlign arrow_alignment = PBL_IF_RECT_ELSE(GAlignBottomRight, GAlignBottom);;
   grect_align(&arrow_bounds, layer_bounds, arrow_alignment, false /* clip */);
-  const int16_t arrow_nudge_y = PBL_IF_RECT_ELSE(7, -8);
+  const int16_t arrow_nudge_y = PBL_IF_RECT_ELSE(-3, -8);
   arrow_bounds.origin.y += arrow_nudge_y;
 
   // FIXME PBL-43428:


### PR DESCRIPTION
This is my implementation of a part of the new notification design by @lavglaab.

It adds the Attribute AttributeIdBannerTitle that allows a BannerTitle to be set on Pebbles.
If a BannerTitle isn't set, the notification will look the same as before.

For BW Watches (currently only silk), instead of dithering we use a black background and invert the icon.

This is part of #48.

Here are some demo videos I recorded for
[Snowy (Pebble Time)](https://youtu.be/lTNziMlDT4o)
[Spalding (Pebble Time Round](https://youtu.be/p2nQHbV7bls)
[Silk (Pebble 2)](https://youtu.be/luMkGjj4yiI)