### PR TITLE
Integrate NimBLE stack and CC2564X UART transport implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Setup emsdk cache
         id: cache-emsdk
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{env.EM_CACHE_FOLDER}}
           key: emsdk-${{env.EM_VERSION}}-${{ runner.os }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "src/bluetooth-fw/nimble/vendor/mynewt-nimble"]
 	path = src/bluetooth-fw/nimble/vendor/mynewt-nimble
 	url = https://github.com/apache/mynewt-nimble.git
+[submodule "src/bluetooth-fw/nimble/vendor/ti-service-packs"]
+	path = src/bluetooth-fw/nimble/vendor/ti-service-packs
+	url = https://git.ti.com/git/ti-bt/service-packs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "src/fw/vendor/stm32-sdk"]
 	path = src/fw/vendor/stm32-sdk
 	url = https://github.com/pebble-dev/stm32-sdk.git
+[submodule "src/bluetooth-fw/nimble/vendor/mynewt-nimble"]
+	path = src/bluetooth-fw/nimble/vendor/mynewt-nimble
+	url = https://github.com/apache/mynewt-nimble.git

--- a/src/bluetooth-fw/nimble/adv_reconnect.c
+++ b/src/bluetooth-fw/nimble/adv_reconnect.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/adv_reconnect.h>
+
+#include "comm/ble/gap_le_advert.h"
+
+const GAPLEAdvertisingJobTerm *bt_driver_adv_reconnect_get_job_terms(size_t *num_terms_out) {
+  *num_terms_out = 0;
+  return NULL;
+}

--- a/src/bluetooth-fw/nimble/advert.c
+++ b/src/bluetooth-fw/nimble/advert.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/bt_driver_advert.h>
+
+void bt_driver_advert_advertising_disable(void) {}
+
+bool bt_driver_advert_is_connectable(void) { return false; }
+
+bool bt_driver_advert_client_get_tx_power(int8_t *tx_power) { return false; }
+
+void bt_driver_advert_set_advertising_data(const BLEAdData *ad_data) {}
+
+bool bt_driver_advert_advertising_enable(uint32_t min_interval_ms, uint32_t max_interval_ms,
+                                         bool enable_scan_resp) {
+  return false;
+}
+
+bool bt_driver_advert_client_has_cycled(void) { return false; }
+
+void bt_driver_advert_client_set_cycled(bool has_cycled) {}
+
+bool bt_driver_advert_should_not_cycle(void) { return false; }

--- a/src/bluetooth-fw/nimble/analytics.c
+++ b/src/bluetooth-fw/nimble/analytics.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/analytics.h>
+#include <bluetooth/bluetooth_types.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "comm/ble/gap_le_connection.h"
+
+bool bt_driver_analytics_get_connection_quality(const BTDeviceInternal *address,
+                                                uint8_t *link_quality_out, int8_t *rssi_out) {
+  return false;
+}
+
+bool bt_driver_analytics_collect_ble_parameters(const BTDeviceInternal *addr,
+                                                LEChannelMap *le_chan_map_res) {
+  return false;
+}
+
+void bt_driver_analytics_external_collect_chip_specific_parameters(void) {}
+
+void bt_driver_analytics_external_collect_bt_chip_heartbeat(void) {}
+
+bool bt_driver_analytics_get_conn_event_stats(SlaveConnEventStats *stats) {
+  return false;  // Info not available
+}

--- a/src/bluetooth-fw/nimble/bonding_sync.c
+++ b/src/bluetooth-fw/nimble/bonding_sync.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/bonding_sync.h>
+#include <bluetooth/sm_types.h>
+
+void bt_driver_handle_host_added_bonding(const BleBonding *bonding) {}
+
+void bt_driver_handle_host_removed_bonding(const BleBonding *bonding) {}

--- a/src/bluetooth-fw/nimble/bt_classic_stubs.c
+++ b/src/bluetooth-fw/nimble/bt_classic_stubs.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/classic_connect.h>
+
+void bt_driver_classic_disconnect(const BTDeviceAddress* address) {}
+
+bool bt_driver_classic_is_connected(void) { return false; }
+
+bool bt_driver_classic_copy_connected_address(BTDeviceAddress* address) { return false; }
+
+bool bt_driver_classic_copy_connected_device_name(char nm[BT_DEVICE_NAME_BUFFER_SIZE]) {
+  return false;
+}

--- a/src/bluetooth-fw/nimble/bt_test.c
+++ b/src/bluetooth-fw/nimble/bt_test.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/bt_test.h>
+
+void bt_driver_test_start(void) {}
+
+void bt_driver_test_enter_hci_passthrough(void) {}
+
+void bt_driver_test_handle_hci_passthrough_character(char c, bool *should_context_switch) {}
+
+bool bt_driver_test_enter_rf_test_mode(void) { return true; }
+
+void bt_driver_test_set_spoof_address(const BTDeviceAddress *addr) {}
+
+void bt_driver_test_stop(void) {}
+
+bool bt_driver_test_selftest(void) { return true; }
+
+bool bt_driver_test_mfi_chip_selftest(void) { return false; }
+
+void bt_driver_core_dump(BtleCoreDump type) {}

--- a/src/bluetooth-fw/nimble/chipset/cc2564/cc2564.c
+++ b/src/bluetooth-fw/nimble/chipset/cc2564/cc2564.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "board/board.h"
+#include "drivers/gpio.h"
+#include "kernel/util/sleep.h"
+#include "resource/resource.h"
+#include "resource/resource_ids.auto.h"
+#include "resource/resource_mapped.h"
+
+typedef struct PACKED {
+  uint8_t type;
+  uint16_t opcode;
+  uint8_t size;
+} BTSHCICommand;
+
+extern void ble_queue_cmd(void *buf, bool needs_free);
+
+static bool ble_run_bts(const ResAppNum bts_file) {
+  size_t i = 0;
+  size_t bts_len = 0;
+
+  if (!resource_is_valid(SYSTEM_APP, bts_file)) {
+    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Can't load BT service pack: bad system resources!");
+    return false;
+  }
+
+  PebbleTask task = pebble_task_get_current();
+  resource_mapped_use(task);
+
+  const uint8_t *bts_data =
+      resource_get_readonly_bytes(SYSTEM_APP, bts_file, &bts_len, true /* is_privileged */);
+
+  while (i < bts_len) {
+    BTSHCICommand *command = (BTSHCICommand *)&bts_data[i];
+    i += sizeof(BTSHCICommand) + command->size;
+
+    // skip update baud rate command and sleep mode config
+    // TODO: re-add sleep mode config and deal with entering/exiting sleep mode
+    if (command->opcode == 0xFF36 || command->opcode == 0xFD0C) {
+      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO, "ble_bts: Skipping opcode 0x%X", command->opcode);
+      continue;
+    }
+    ble_queue_cmd(&command->opcode, false);
+  }
+
+  resource_mapped_release(task);
+
+  return true;
+}
+
+void ble_chipset_init(void) {
+  gpio_output_init(&BOARD_CONFIG_BT_COMMON.reset, GPIO_OType_PP, GPIO_Speed_25MHz);
+  gpio_output_set(&BOARD_CONFIG_BT_COMMON.reset, true);
+  psleep(100);
+  gpio_output_set(&BOARD_CONFIG_BT_COMMON.reset, false);
+}
+
+bool ble_chipset_start(void) {
+  if (!ble_run_bts(RESOURCE_ID_BT_PATCH)) return false;
+
+  // HACK: this is just here to let the service pack commands get processed before we continue
+  psleep(500);
+
+  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO, "bts files sent");
+
+  return true;
+}

--- a/src/bluetooth-fw/nimble/chipset/cc2564/wscript
+++ b/src/bluetooth-fw/nimble/chipset/cc2564/wscript
@@ -1,0 +1,29 @@
+import waftools.cc2564_service_pack_convert
+
+def configure(conf):
+    pass
+
+
+def build(bld):
+    service_pack_bin_bld_node = bld.srcnode.get_bld().make_node(
+        'resources/common/raw/bt_patch.bin')
+    service_pack_bts = '../../vendor/ti-service-packs/initscripts/TIInit_6.7.16.bts'
+    bld(rule=waftools.cc2564_service_pack_convert.wafrule,
+        source=service_pack_bts,
+        target=service_pack_bin_bld_node)
+    bld.DYNAMIC_RESOURCES.append(service_pack_bin_bld_node)
+    
+    chipset_source = bld.path.ant_glob([
+        '*.c',
+    ])
+
+    bld.objects(
+        source=chipset_source,
+        target='bt_chipset_driver',
+        defines=['FILE_LOG_COLOR=LOG_COLOR_BLUE'],
+        use=[
+          'fw_includes',
+          'freertos',
+          'root_includes',
+        ],
+    )

--- a/src/bluetooth-fw/nimble/chipset/include/ble_chipset.h
+++ b/src/bluetooth-fw/nimble/chipset/include/ble_chipset.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _BLE_CHIPSET_H_
+#define _BLE_CHIPSET_H_
+
+void ble_chipset_init(void);
+bool ble_chipset_start(void);
+
+#endif  // _BLE_CHIPSET_H_

--- a/src/bluetooth-fw/nimble/comm.c
+++ b/src/bluetooth-fw/nimble/comm.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdbool.h>
+
+#include "bluetooth/bt_driver_comm.h"
+#include "kernel/event_loop.h"
+
+static void prv_send_job(void *data) {
+  CommSession *session = (CommSession *)data;
+  bt_driver_run_send_next_job(session, true);
+}
+
+bool bt_driver_comm_schedule_send_next_job(CommSession *session) {
+  launcher_task_add_callback(prv_send_job, session);
+  return true;  // we croak if a task cannot be scheduled on KernelMain
+}
+
+bool bt_driver_comm_is_current_task_send_next_task(void) { return launcher_task_is_current_task(); }

--- a/src/bluetooth-fw/nimble/connectability.c
+++ b/src/bluetooth-fw/nimble/connectability.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/connectability.h>
+
+void bt_driver_classic_update_connectability(void) {}

--- a/src/bluetooth-fw/nimble/features.c
+++ b/src/bluetooth-fw/nimble/features.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/features.h>
+
+bool bt_driver_supports_bt_classic(void) { return false; }

--- a/src/bluetooth-fw/nimble/gap_le_connect.c
+++ b/src/bluetooth-fw/nimble/gap_le_connect.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bluetooth/gap_le_connect.h"
+
+int bt_driver_gap_le_disconnect(const BTDeviceInternal *peer_address) { return 0; }

--- a/src/bluetooth-fw/nimble/gap_le_device_name.c
+++ b/src/bluetooth-fw/nimble/gap_le_device_name.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bluetooth/gap_le_device_name.h"
+
+void bt_driver_gap_le_device_name_request(const BTDeviceInternal *connection) {}
+
+void bt_driver_gap_le_device_name_request_all(void) {}

--- a/src/bluetooth-fw/nimble/gap_le_scan.c
+++ b/src/bluetooth-fw/nimble/gap_le_scan.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bluetooth/gap_le_scan.h"
+
+bool bt_driver_start_le_scan(bool active_scan, bool use_white_list_filter, bool filter_dups,
+                             uint16_t scan_interval_ms, uint16_t scan_window_ms) {
+  return true;
+}
+
+bool bt_driver_stop_le_scan(void) { return true; }

--- a/src/bluetooth-fw/nimble/gatt.c
+++ b/src/bluetooth-fw/nimble/gatt.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/gatt.h>
+#include <inttypes.h>
+
+void bt_driver_gatt_respond_read_subscription(uint32_t transaction_id, uint16_t response_code) {}
+
+void bt_driver_gatt_send_changed_indication(uint32_t connection_id, const ATTHandleRange *data) {}

--- a/src/bluetooth-fw/nimble/gatt_client_discovery.c
+++ b/src/bluetooth-fw/nimble/gatt_client_discovery.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/bluetooth_types.h>
+#include <bluetooth/gatt.h>
+#include <inttypes.h>
+
+// -------------------------------------------------------------------------------------------------
+// Gatt Client Discovery API calls
+
+BTErrno bt_driver_gatt_start_discovery_range(const GAPLEConnection *connection,
+                                             const ATTHandleRange *data) {
+  return 0;
+}
+
+BTErrno bt_driver_gatt_stop_discovery(GAPLEConnection *connection) { return 0; }
+
+void bt_driver_gatt_handle_discovery_abandoned(void) {}

--- a/src/bluetooth-fw/nimble/gatt_client_operations.c
+++ b/src/bluetooth-fw/nimble/gatt_client_operations.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/gatt.h>
+#include <btutil/bt_device.h>
+
+BTErrno bt_driver_gatt_write_without_response(GAPLEConnection *connection, const uint8_t *value,
+                                              size_t value_length, uint16_t att_handle) {
+  return 0;
+}
+
+BTErrno bt_driver_gatt_write(GAPLEConnection *connection, const uint8_t *value, size_t value_length,
+                             uint16_t att_handle, void *context) {
+  return 0;
+}
+
+BTErrno bt_driver_gatt_read(GAPLEConnection *connection, uint16_t att_handle, void *context) {
+  return 0;
+}

--- a/src/bluetooth-fw/nimble/hrm_service.c
+++ b/src/bluetooth-fw/nimble/hrm_service.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/hrm_service.h>
+
+bool bt_driver_is_hrm_service_supported(void) { return false; }
+
+void bt_driver_hrm_service_handle_measurement(const BleHrmServiceMeasurement *measurement,
+                                              const BTDeviceInternal *permitted_devices,
+                                              size_t num_permitted_devices) {}

--- a/src/bluetooth-fw/nimble/id.c
+++ b/src/bluetooth-fw/nimble/id.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/bluetooth_types.h>
+#include <bluetooth/id.h>
+#include <string.h>
+
+void bt_driver_id_set_local_device_name(const char device_name[BT_DEVICE_NAME_BUFFER_SIZE]) {}
+
+void bt_driver_id_copy_local_identity_address(BTDeviceAddress *addr_out) {
+  memset(addr_out, 0xAA, sizeof(*addr_out));
+}
+
+void bt_driver_set_local_address(bool allow_cycling, const BTDeviceAddress *pinned_address) {}
+
+void bt_driver_id_copy_chip_info_string(char *dest, size_t dest_size) {
+  strncpy(dest, "QEMU", dest_size);
+}
+
+bool bt_driver_id_generate_private_resolvable_address(BTDeviceAddress *address_out) {
+  *address_out = (BTDeviceAddress){};
+  return true;
+}

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -17,16 +17,116 @@
 #include <bluetooth/init.h>
 #include <stdlib.h>
 
+#include "FreeRTOS.h"
 #include "comm/bt_lock.h"
+#include "host/ble_hs.h"
+#include "host/ble_hs_stop.h"
+#include "host/util/util.h"
 #include "kernel/event_loop.h"
+#include "nimble/nimble_port.h"
+#include "os/tick.h"
 #include "pebble_errors.h"
+#include "semphr.h"
+#include "services/ans/ble_svc_ans.h"
+#include "services/dis/ble_svc_dis.h"
+#include "services/gap/ble_svc_gap.h"
+#include "services/gatt/ble_svc_gatt.h"
 #include "system/logging.h"
+#include "system/passert.h"
 
-void bt_driver_init(void) { bt_lock_init(); }
+static const uint32_t s_bt_stack_start_stop_timeout_ms = 500;
 
-bool bt_driver_start(BTDriverConfig *config) { return true; }
+void ble_store_ram_init(void);
 
-void bt_driver_stop(void) { }
+static TaskHandle_t s_host_task_handle;
+static SemaphoreHandle_t s_host_started;
+static SemaphoreHandle_t s_host_stopped;
+static DisInfo s_dis_info;
+
+static void sync_cb(void) {
+  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO, "BT sync_cb");
+  xSemaphoreGive(s_host_started);
+}
+
+static void reset_cb(int reason) {
+  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO, "BT reset_cb, reason: %d", reason);
+}
+
+static void prv_host_task_main(void *unused) {
+  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO, "BT host task started");
+
+  ble_hs_cfg.sync_cb = sync_cb;
+  ble_hs_cfg.reset_cb = reset_cb;
+  ble_hs_cfg.sm_our_key_dist |= BLE_SM_PAIR_KEY_DIST_ENC | BLE_SM_PAIR_KEY_DIST_ID;
+  ble_hs_cfg.sm_their_key_dist |= BLE_SM_PAIR_KEY_DIST_ENC | BLE_SM_PAIR_KEY_DIST_ID;
+  ble_hs_cfg.sm_io_cap = BLE_SM_IO_CAP_NO_IO;
+  ble_hs_cfg.sm_bonding = 1;
+  ble_hs_cfg.sm_sc = 1;
+
+  nimble_port_run();
+}
+
+// ----------------------------------------------------------------------------------------
+void bt_driver_init(void) {
+  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO, "bt_driver_init");
+  bt_lock_init();
+
+  s_host_started = xSemaphoreCreateBinary();
+  s_host_stopped = xSemaphoreCreateBinary();
+
+  nimble_port_init();
+  ble_svc_gap_init();
+  ble_svc_gatt_init();
+  ble_svc_dis_init();
+  ble_store_ram_init();
+
+  TaskParameters_t task_params = {
+      .pvTaskCode = prv_host_task_main,
+      .pcName = "NimbleHost",
+      .usStackDepth = 4000 / sizeof(StackType_t),  // TODO: probably reduce this
+      .uxPriority = (tskIDLE_PRIORITY + 3) | portPRIVILEGE_BIT,
+      .puxStackBuffer = NULL,
+  };
+
+  pebble_task_create(PebbleTask_BTCallback, &task_params, &s_host_task_handle);
+  PBL_ASSERTN(s_host_task_handle);
+}
+
+bool bt_driver_start(BTDriverConfig *config) {
+  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO, "bt_driver_start");
+
+  s_dis_info = config->dis_info;
+  ble_svc_dis_model_number_set(s_dis_info.model_number);
+  ble_svc_dis_serial_number_set(s_dis_info.serial_number);
+  ble_svc_dis_firmware_revision_set(s_dis_info.fw_revision);
+  ble_svc_dis_software_revision_set(s_dis_info.sw_revision);
+  ble_svc_dis_manufacturer_name_set(s_dis_info.manufacturer);
+
+  ble_hs_sched_start();
+  bool started = xSemaphoreTake(s_host_started,
+                                milliseconds_to_ticks(s_bt_stack_start_stop_timeout_ms)) == pdTRUE;
+  if (!started) {
+    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "bt_driver_start timeout");
+    return false;
+  }
+
+  return true;
+}
+
+static void prv_ble_hs_stop_cb(int status, void *arg) {
+  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO, "stop_cb, status: %d", status);
+  xSemaphoreGive(s_host_stopped);
+}
+
+void bt_driver_stop(void) {
+  static struct ble_hs_stop_listener listener;
+  ble_hs_stop(&listener, prv_ble_hs_stop_cb, NULL);
+  if (xSemaphoreTake(s_host_stopped, milliseconds_to_ticks(s_bt_stack_start_stop_timeout_ms)) ==
+      pdFALSE) {
+    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "bt_driver_stop timeout");
+  }
+  ble_gatts_reset();
+}
 
 void bt_driver_power_down_controller_on_boot(void) {
   // no-op

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/init.h>
+#include <stdlib.h>
+
+#include "comm/bt_lock.h"
+#include "kernel/event_loop.h"
+#include "pebble_errors.h"
+#include "system/logging.h"
+
+void bt_driver_init(void) { bt_lock_init(); }
+
+bool bt_driver_start(BTDriverConfig *config) { return true; }
+
+void bt_driver_stop(void) { }
+
+void bt_driver_power_down_controller_on_boot(void) {
+  // no-op
+}

--- a/src/bluetooth-fw/nimble/logging.c
+++ b/src/bluetooth-fw/nimble/logging.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+void hc_endpoint_logging_set_level(uint8_t level) {}
+
+bool hc_endpoint_logging_get_level(uint8_t *level) { return false; }

--- a/src/bluetooth-fw/nimble/pairability.c
+++ b/src/bluetooth-fw/nimble/pairability.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/pairability.h>
+
+void bt_driver_le_pairability_set_enabled(bool enabled) {}
+
+void bt_driver_classic_pairability_set_enabled(bool enabled) {}

--- a/src/bluetooth-fw/nimble/pairing_confirm.c
+++ b/src/bluetooth-fw/nimble/pairing_confirm.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/pairing_confirm.h>
+
+void bt_driver_pairing_confirm(const PairingUserConfirmationCtx *ctx, bool is_confirmed) {}

--- a/src/bluetooth-fw/nimble/pebble_pairing_service.c
+++ b/src/bluetooth-fw/nimble/pebble_pairing_service.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bluetooth/pebble_pairing_service.h>
+
+void bt_driver_pebble_pairing_service_handle_status_change(const GAPLEConnection *connection) {}
+
+void bt_driver_pebble_pairing_service_handle_gatt_mtu_change(const GAPLEConnection *connection) {}

--- a/src/bluetooth-fw/nimble/port/include/console/console.h
+++ b/src/bluetooth-fw/nimble/port/include/console/console.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CONSOLE_H__
+#define __CONSOLE_H__
+
+#include "system/logging.h"
+
+#define console_printf(_fmt, ...) PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
+
+#endif /* __CONSOLE_H__ */

--- a/src/bluetooth-fw/nimble/port/include/nimble/nimble_npl_os.h
+++ b/src/bluetooth-fw/nimble/port/include/nimble/nimble_npl_os.h
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2025 Google LLC
+ * Copyright 2015-2024 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This is derived from the freertos port provided by NimBLE
+// and modified to suit Pebble OS (timers, mutexes).
+
+#ifndef _NIMBLE_NPL_OS_H_
+#define _NIMBLE_NPL_OS_H_
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "FreeRTOS.h"
+#include "kernel/pbl_malloc.h"
+#include "os/mutex.h"
+#include "queue.h"
+#include "semphr.h"
+#include "services/common/new_timer/new_timer.h"
+#include "task.h"
+#include "timers.h"
+
+#define BLE_NPL_OS_ALIGNMENT 4
+
+#define BLE_NPL_TIME_FOREVER portMAX_DELAY
+
+typedef uint32_t ble_npl_time_t;
+typedef int32_t ble_npl_stime_t;
+
+struct ble_npl_event {
+  bool queued;
+  ble_npl_event_fn *fn;
+  void *arg;
+};
+
+struct ble_npl_eventq {
+  QueueHandle_t q;
+};
+
+struct ble_npl_callout {
+  TimerID handle;
+  struct ble_npl_eventq *evq;
+  struct ble_npl_event ev;
+  uint64_t ticks;
+};
+
+struct ble_npl_mutex {
+  PebbleRecursiveMutex *handle;
+};
+
+struct ble_npl_sem {
+  SemaphoreHandle_t handle;
+};
+
+#include "npl_pebble.h"
+
+static inline bool ble_npl_os_started(void) {
+  return xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED;
+}
+
+static inline void *ble_npl_get_current_task_id(void) { return xTaskGetCurrentTaskHandle(); }
+
+static inline void ble_npl_eventq_init(struct ble_npl_eventq *evq) {
+  evq->q = xQueueCreate(32, sizeof(struct ble_npl_eventq *));
+}
+
+static inline struct ble_npl_event *ble_npl_eventq_get(struct ble_npl_eventq *evq,
+                                                       ble_npl_time_t tmo) {
+  return npl_pebble_eventq_get(evq, tmo);
+}
+
+static inline void ble_npl_eventq_put(struct ble_npl_eventq *evq, struct ble_npl_event *ev) {
+  npl_pebble_eventq_put(evq, ev);
+}
+
+static inline void ble_npl_eventq_remove(struct ble_npl_eventq *evq, struct ble_npl_event *ev) {
+  npl_pebble_eventq_remove(evq, ev);
+}
+
+static inline void ble_npl_event_run(struct ble_npl_event *ev) { ev->fn(ev); }
+
+static inline bool ble_npl_eventq_is_empty(struct ble_npl_eventq *evq) {
+  return xQueueIsQueueEmptyFromISR(evq->q);
+}
+
+static inline void ble_npl_event_init(struct ble_npl_event *ev, ble_npl_event_fn *fn, void *arg) {
+  memset(ev, 0, sizeof(*ev));
+  ev->fn = fn;
+  ev->arg = arg;
+}
+
+static inline bool ble_npl_event_is_queued(struct ble_npl_event *ev) { return ev->queued; }
+
+static inline void *ble_npl_event_get_arg(struct ble_npl_event *ev) { return ev->arg; }
+
+static inline void ble_npl_event_set_arg(struct ble_npl_event *ev, void *arg) { ev->arg = arg; }
+
+static inline ble_npl_error_t ble_npl_mutex_init(struct ble_npl_mutex *mu) {
+  return npl_pebble_mutex_init(mu);
+}
+
+static inline ble_npl_error_t ble_npl_mutex_pend(struct ble_npl_mutex *mu, ble_npl_time_t timeout) {
+  return npl_pebble_mutex_pend(mu, timeout);
+}
+
+static inline ble_npl_error_t ble_npl_mutex_release(struct ble_npl_mutex *mu) {
+  return npl_pebble_mutex_release(mu);
+}
+
+static inline ble_npl_error_t ble_npl_sem_init(struct ble_npl_sem *sem, uint16_t tokens) {
+  return npl_pebble_sem_init(sem, tokens);
+}
+
+static inline ble_npl_error_t ble_npl_sem_pend(struct ble_npl_sem *sem, ble_npl_time_t timeout) {
+  return npl_pebble_sem_pend(sem, timeout);
+}
+
+static inline ble_npl_error_t ble_npl_sem_release(struct ble_npl_sem *sem) {
+  return npl_pebble_sem_release(sem);
+}
+
+static inline uint16_t ble_npl_sem_get_count(struct ble_npl_sem *sem) {
+  return uxSemaphoreGetCount(sem->handle);
+}
+
+static inline void ble_npl_callout_init(struct ble_npl_callout *co, struct ble_npl_eventq *evq,
+                                        ble_npl_event_fn *ev_cb, void *ev_arg) {
+  npl_pebble_callout_init(co, evq, ev_cb, ev_arg);
+}
+
+static inline ble_npl_error_t ble_npl_callout_reset(struct ble_npl_callout *co,
+                                                    ble_npl_time_t ticks) {
+  return npl_pebble_callout_reset(co, ticks);
+}
+
+static inline void ble_npl_callout_stop(struct ble_npl_callout *co) { npl_pebble_callout_stop(co); }
+
+static inline bool ble_npl_callout_is_active(struct ble_npl_callout *co) {
+  return npl_pebble_callout_is_active(co);
+}
+
+static inline ble_npl_time_t ble_npl_callout_get_ticks(struct ble_npl_callout *co) {
+  return npl_pebble_callout_get_ticks(co);
+}
+
+static inline uint32_t ble_npl_callout_remaining_ticks(struct ble_npl_callout *co,
+                                                       ble_npl_time_t time) {
+  return npl_pebble_callout_remaining_ticks(co, time);
+}
+
+static inline void ble_npl_callout_set_arg(struct ble_npl_callout *co, void *arg) {
+  co->ev.arg = arg;
+}
+
+static inline uint32_t ble_npl_time_get(void) { return xTaskGetTickCountFromISR(); }
+
+static inline ble_npl_error_t ble_npl_time_ms_to_ticks(uint32_t ms, ble_npl_time_t *out_ticks) {
+  return npl_pebble_time_ms_to_ticks(ms, out_ticks);
+}
+
+static inline ble_npl_error_t ble_npl_time_ticks_to_ms(ble_npl_time_t ticks, uint32_t *out_ms) {
+  return npl_pebble_time_ticks_to_ms(ticks, out_ms);
+}
+
+static inline ble_npl_time_t ble_npl_time_ms_to_ticks32(uint32_t ms) { return ms; }
+
+static inline uint32_t ble_npl_time_ticks_to_ms32(ble_npl_time_t ticks) { return ticks; }
+
+static inline void ble_npl_time_delay(ble_npl_time_t ticks) { vTaskDelay(ticks); }
+
+#if NIMBLE_CFG_CONTROLLER
+static inline void ble_npl_hw_set_isr(int irqn, void (*addr)(void)) {
+  npl_pebble_hw_set_isr(irqn, addr);
+}
+#endif
+
+static inline uint32_t ble_npl_hw_enter_critical(void) {
+  vPortEnterCritical();
+  return 0;
+}
+
+static inline void ble_npl_hw_exit_critical(uint32_t ctx) { vPortExitCritical(); }
+
+#define realloc kernel_realloc
+
+#endif /* _NPL_H_ */

--- a/src/bluetooth-fw/nimble/port/include/nimble/nimble_npl_os_log.h
+++ b/src/bluetooth-fw/nimble/port/include/nimble/nimble_npl_os_log.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _NIMBLE_NPL_OS_LOG_H_
+#define _NIMBLE_NPL_OS_LOG_H_
+
+#include <stdarg.h>
+
+#include "system/logging.h"
+
+// TODO: This doesn't respect log levels and is generally pretty noisy...
+#define BLE_NPL_LOG_IMPL(lvl)                                                        \
+  static inline void _BLE_NPL_LOG_CAT(BLE_NPL_LOG_MODULE, _BLE_NPL_LOG_CAT(_, lvl))( \
+      const char *fmt, ...) {                                                        \
+    va_list args;                                                                    \
+    va_start(args, fmt);                                                             \
+    pbl_log_vargs(LOG_LEVEL_INFO, __FILE__, __LINE__, fmt, args);                    \
+    va_end(args);                                                                    \
+  }
+
+#endif /* _NIMBLE_NPL_OS_LOG_H_ */

--- a/src/bluetooth-fw/nimble/port/include/nimble/npl_pebble.h
+++ b/src/bluetooth-fw/nimble/port/include/nimble/npl_pebble.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _NPL_PEBBLE_H_
+#define _NPL_PEBBLE_H_
+
+struct ble_npl_event *npl_pebble_eventq_get(struct ble_npl_eventq *evq, ble_npl_time_t tmo);
+
+void npl_pebble_eventq_put(struct ble_npl_eventq *evq, struct ble_npl_event *ev);
+
+void npl_pebble_eventq_remove(struct ble_npl_eventq *evq, struct ble_npl_event *ev);
+
+ble_npl_error_t npl_pebble_mutex_init(struct ble_npl_mutex *mu);
+
+ble_npl_error_t npl_pebble_mutex_pend(struct ble_npl_mutex *mu, ble_npl_time_t timeout);
+
+ble_npl_error_t npl_pebble_mutex_release(struct ble_npl_mutex *mu);
+
+ble_npl_error_t npl_pebble_sem_init(struct ble_npl_sem *sem, uint16_t tokens);
+
+ble_npl_error_t npl_pebble_sem_pend(struct ble_npl_sem *sem, ble_npl_time_t timeout);
+
+ble_npl_error_t npl_pebble_sem_release(struct ble_npl_sem *sem);
+
+void npl_pebble_callout_init(struct ble_npl_callout *co, struct ble_npl_eventq *evq,
+                             ble_npl_event_fn *ev_cb, void *ev_arg);
+
+ble_npl_error_t npl_pebble_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks);
+
+void npl_pebble_callout_stop(struct ble_npl_callout *co);
+
+bool npl_pebble_callout_is_active(struct ble_npl_callout *co);
+
+ble_npl_error_t npl_pebble_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks);
+
+ble_npl_time_t npl_pebble_callout_get_ticks(struct ble_npl_callout *co);
+
+ble_npl_time_t npl_pebble_callout_remaining_ticks(struct ble_npl_callout *co, ble_npl_time_t now);
+
+ble_npl_error_t npl_pebble_time_ms_to_ticks(uint32_t ms, ble_npl_time_t *out_ticks);
+
+ble_npl_error_t npl_pebble_time_ticks_to_ms(ble_npl_time_t ticks, uint32_t *out_ms);
+
+void npl_pebble_hw_set_isr(int irqn, void (*addr)(void));
+
+uint32_t npl_pebble_hw_enter_critical(void);
+
+void npl_pebble_hw_exit_critical(uint32_t ctx);
+
+#endif /* _NPL_PEBBLE_H_ */

--- a/src/bluetooth-fw/nimble/port/src/hci_uart_transport.c
+++ b/src/bluetooth-fw/nimble/port/src/hci_uart_transport.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO: transport.h needs os_mbuf.h to be included first
+// clang-format off
+#include "os/os_mbuf.h"
+#include "nimble/transport.h"
+// clang-format on
+
+void ble_transport_ll_init(void) {}
+
+int ble_transport_to_ll_acl_impl(struct os_mbuf *om) {
+  os_mbuf_free(om);
+  return 0;
+}
+
+int ble_transport_to_ll_cmd_impl(void *buf) {
+  ble_transport_free(buf);
+  return 0;
+}

--- a/src/bluetooth-fw/nimble/port/src/hci_uart_transport.c
+++ b/src/bluetooth-fw/nimble/port/src/hci_uart_transport.c
@@ -17,17 +17,249 @@
 // TODO: transport.h needs os_mbuf.h to be included first
 // clang-format off
 #include "os/os_mbuf.h"
-#include "nimble/transport.h"
 // clang-format on
 
-void ble_transport_ll_init(void) {}
+#include "ble_chipset.h"
 
-int ble_transport_to_ll_acl_impl(struct os_mbuf *om) {
-  os_mbuf_free(om);
+#include "board/board.h"
+#include "drivers/uart.h"
+#include "kernel/pebble_tasks.h"
+#include "nimble/transport.h"
+#include "nimble/transport/hci_h4.h"
+#include "nimble/transport_impl.h"
+#include "os/os_mempool.h"
+#include "queue.h"
+#include "system/passert.h"
+#include "util/circular_buffer.h"
+#include "util/math.h"
+
+struct uart_tx {
+  uint8_t type;
+  uint8_t sent_type;
+  uint16_t len;
+  uint16_t idx;
+
+  struct os_mbuf *om;
+  uint8_t *buf;
+  bool buf_needs_free;
+};
+
+static TaskHandle_t s_rx_task_handle;
+static CircularBuffer s_rx_buffer;
+static uint8_t s_rx_storage[1024];
+static SemaphoreHandle_t s_rx_data_ready;
+
+static QueueHandle_t s_tx_queue;
+static struct hci_h4_sm hci_uart_h4sm;
+static bool chipset_start_done = false;
+
+static void prv_lock(void) { portENTER_CRITICAL(); }
+
+static void prv_unlock(void) { portEXIT_CRITICAL(); }
+
+static int hci_uart_frame_cb(uint8_t pkt_type, void *data) {
+  // HACK: passing responses to commands Nimble didn't generate causes issues
+  if (!chipset_start_done) {
+    ble_transport_free(data);
+    return 0;
+  }
+
+  switch (pkt_type) {
+    case HCI_H4_ACL:
+      return ble_transport_to_hs_acl(data);
+    case HCI_H4_EVT:
+      return ble_transport_to_hs_evt(data);
+    case HCI_H4_ISO:
+      return ble_transport_to_hs_iso(data);
+    default:
+      WTF;
+  }
+
+  return -1;
+}
+
+static int hci_uart_tx_char(BaseType_t *should_context_switch) {
+  struct uart_tx *tx = NULL;
+  uint8_t ch;
+
+  if (xQueuePeekFromISR(s_tx_queue, &tx) == pdFALSE) return -1;
+
+  if (!tx->sent_type) {
+    tx->sent_type = 1;
+    return tx->type;
+  }
+
+  switch (tx->type) {
+    case HCI_H4_CMD:
+      ch = tx->buf[tx->idx];
+      tx->idx++;
+      if (tx->idx == tx->len) {
+        if (tx->buf_needs_free) ble_transport_free(tx->buf);
+        xQueueReceiveFromISR(s_tx_queue, &tx, should_context_switch);
+        kernel_free(tx);
+      }
+      break;
+    case HCI_H4_ACL:
+    case HCI_H4_ISO:
+      os_mbuf_copydata(tx->om, 0, 1, &ch);
+      os_mbuf_adj(tx->om, 1);
+      tx->len--;
+      if (tx->len == 0) {
+        os_mbuf_free_chain(tx->om);
+        xQueueReceiveFromISR(s_tx_queue, &tx, should_context_switch);
+        kernel_free(tx);
+      }
+      break;
+    default:
+      WTF;
+  }
+
+  return ch;
+}
+
+static void ble_hci_tx_byte(BaseType_t *should_context_switch) {
+  int c = hci_uart_tx_char(should_context_switch);
+  if (c == -1) {
+    uart_set_tx_interrupt_enabled(BLUETOOTH_UART, false);
+  } else {
+    uart_write_byte(BLUETOOTH_UART, c);
+  }
+}
+
+static bool prv_uart_tx_irq_handler(UARTDevice *dev) {
+  BaseType_t should_context_switch = false;
+  ble_hci_tx_byte(&should_context_switch);
+  return should_context_switch;
+}
+
+static bool prv_uart_rx_irq_handler(UARTDevice *dev, uint8_t data,
+                                    const UARTRXErrorFlags *err_flags) {
+  BaseType_t should_context_switch = false;
+
+  prv_lock();
+  PBL_ASSERTN(circular_buffer_get_write_space_remaining(&s_rx_buffer) > 0);
+  circular_buffer_write(&s_rx_buffer, &data, 1);
+  xSemaphoreGiveFromISR(s_rx_data_ready, &should_context_switch);
+  prv_unlock();
+
+  return should_context_switch;
+}
+
+static uint8_t read_buf[64];
+static void prv_rx_task_main(void *unused) {
+  int consumed_bytes;
+  uint16_t bytes_remaining;
+
+  while (true) {
+    xSemaphoreTake(s_rx_data_ready, portMAX_DELAY);
+
+    while (true) {
+      prv_lock();
+
+      bytes_remaining = circular_buffer_get_read_space_remaining(&s_rx_buffer);
+      if (bytes_remaining == 0) {
+        prv_unlock();
+        break;
+      }
+
+      bytes_remaining = MIN(sizeof(read_buf), bytes_remaining);
+      circular_buffer_copy(&s_rx_buffer, &read_buf, bytes_remaining);
+      prv_unlock();
+
+      consumed_bytes = hci_h4_sm_rx(&hci_uart_h4sm, read_buf, bytes_remaining);
+      PBL_ASSERTN(consumed_bytes >= 0);
+
+      prv_lock();
+      circular_buffer_consume(&s_rx_buffer, consumed_bytes);
+      prv_unlock();
+    }
+  }
+}
+
+void ble_transport_ll_init(void) {
+  hci_h4_sm_init(&hci_uart_h4sm, &hci_h4_allocs_from_ll, hci_uart_frame_cb);
+
+  s_tx_queue = xQueueCreate(1, sizeof(struct uart_tx *));
+  PBL_ASSERTN(s_tx_queue);
+
+  s_rx_data_ready = xSemaphoreCreateBinary();
+  circular_buffer_init(&s_rx_buffer, s_rx_storage, sizeof(s_rx_storage));
+
+  ble_chipset_init();
+
+  uart_init(BLUETOOTH_UART);
+  uart_set_baud_rate(BLUETOOTH_UART, 115200);
+  uart_set_rx_interrupt_handler(BLUETOOTH_UART, prv_uart_rx_irq_handler);
+  uart_set_tx_interrupt_handler(BLUETOOTH_UART, prv_uart_tx_irq_handler);
+  uart_set_rx_interrupt_enabled(BLUETOOTH_UART, true);
+
+  TaskParameters_t task_params = {
+      .pvTaskCode = prv_rx_task_main,
+      .pcName = "NimbleRX",
+      .usStackDepth = 4000 / sizeof(StackType_t), // TODO: can probably be reduced
+      .uxPriority = (tskIDLE_PRIORITY + 3) | portPRIVILEGE_BIT,
+      .puxStackBuffer = NULL,
+  };
+
+  pebble_task_create(PebbleTask_BTRX, &task_params, &s_rx_task_handle);
+  PBL_ASSERTN(s_rx_task_handle);
+
+  if (ble_chipset_start()) {
+    chipset_start_done = true;
+  }
+}
+
+static void ble_transport_tx_item(struct uart_tx *tx_item) {
+  xQueueSendToBack(s_tx_queue, &tx_item, portMAX_DELAY);
+  uart_set_tx_interrupt_enabled(BLUETOOTH_UART, true);
+}
+
+void ble_queue_cmd(void *buf, bool needs_free) {
+  struct uart_tx *tx_item = kernel_malloc(sizeof(struct uart_tx));
+  PBL_ASSERTN(tx_item);
+  tx_item->type = HCI_H4_CMD;
+  tx_item->sent_type = 0;
+  tx_item->len = 3 + ((uint8_t *)buf)[2];
+  tx_item->buf = buf;
+  tx_item->idx = 0;
+  tx_item->om = NULL;
+  tx_item->buf_needs_free = needs_free;
+
+  ble_transport_tx_item(tx_item);
+}
+
+/* APIs to be implemented by HS/LL side of transports */
+int ble_transport_to_ll_cmd_impl(void *buf) {
+  ble_queue_cmd(buf, true);
   return 0;
 }
 
-int ble_transport_to_ll_cmd_impl(void *buf) {
-  ble_transport_free(buf);
+int ble_transport_to_ll_acl_impl(struct os_mbuf *om) {
+  struct uart_tx *tx_item = kernel_malloc(sizeof(struct uart_tx));
+  PBL_ASSERTN(tx_item);
+  tx_item->type = HCI_H4_ACL;
+  tx_item->sent_type = 0;
+  tx_item->len = OS_MBUF_PKTLEN(om);
+  tx_item->buf = NULL;
+  tx_item->idx = 0;
+  tx_item->om = om;
+
+  ble_transport_tx_item(tx_item);
+
+  return 0;
+}
+
+int ble_transport_to_ll_iso_impl(struct os_mbuf *om) {
+  struct uart_tx *tx_item = kernel_malloc(sizeof(struct uart_tx));
+  PBL_ASSERTN(tx_item);
+  tx_item->type = HCI_H4_ISO;
+  tx_item->sent_type = 0;
+  tx_item->len = OS_MBUF_PKTLEN(om);
+  tx_item->buf = NULL;
+  tx_item->idx = 0;
+  tx_item->om = om;
+
+  ble_transport_tx_item(tx_item);
+
   return 0;
 }

--- a/src/bluetooth-fw/nimble/port/src/npl_os_pebble.c
+++ b/src/bluetooth-fw/nimble/port/src/npl_os_pebble.c
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2025 Google LLC
+ * Copyright 2015-2024 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This is derived from the freertos port provided by NimBLE
+// and modified to suit Pebble OS (timers, mutexes).
+
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "mcu/interrupts.h"
+#include "nimble/nimble_npl.h"
+#include "os/mutex.h"
+#include "os/tick.h"
+#include "services/common/new_timer/new_timer.h"
+#include "system/logging.h"
+#include "system/passert.h"
+
+struct ble_npl_event *npl_pebble_eventq_get(struct ble_npl_eventq *evq, ble_npl_time_t tmo) {
+  struct ble_npl_event *ev = NULL;
+  BaseType_t woken;
+  BaseType_t ret;
+
+  if (mcu_state_is_isr()) {
+    assert(tmo == 0);
+    ret = xQueueReceiveFromISR(evq->q, &ev, &woken);
+    portYIELD_FROM_ISR(woken);
+  } else {
+    ret = xQueueReceive(evq->q, &ev, tmo);
+  }
+  assert(ret == pdPASS || ret == errQUEUE_EMPTY);
+
+  if (ev) {
+    ev->queued = false;
+  }
+
+  return ev;
+}
+
+void npl_pebble_eventq_put(struct ble_npl_eventq *evq, struct ble_npl_event *ev) {
+  BaseType_t woken;
+  BaseType_t ret;
+
+  if (ev->queued) {
+    return;
+  }
+
+  ev->queued = true;
+
+  if (mcu_state_is_isr()) {
+    ret = xQueueSendToBackFromISR(evq->q, &ev, &woken);
+    portYIELD_FROM_ISR(woken);
+  } else {
+    ret = xQueueSendToBack(evq->q, &ev, portMAX_DELAY);
+  }
+
+  assert(ret == pdPASS);
+}
+
+void npl_pebble_eventq_remove(struct ble_npl_eventq *evq, struct ble_npl_event *ev) {
+  struct ble_npl_event *tmp_ev;
+  BaseType_t ret;
+  int i;
+  int count;
+  BaseType_t woken, woken2;
+
+  if (!ev->queued) {
+    return;
+  }
+
+  /*
+   * XXX We cannot extract element from inside FreeRTOS queue so as a quick
+   * workaround we'll just remove all elements and add them back except the
+   * one we need to remove. This is silly, but works for now - we probably
+   * better use counting semaphore with os_queue to handle this in future.
+   */
+
+  if (mcu_state_is_isr()) {
+    woken = pdFALSE;
+
+    count = uxQueueMessagesWaitingFromISR(evq->q);
+    for (i = 0; i < count; i++) {
+      ret = xQueueReceiveFromISR(evq->q, &tmp_ev, &woken2);
+      assert(ret == pdPASS);
+      woken |= woken2;
+
+      if (tmp_ev == ev) {
+        continue;
+      }
+
+      ret = xQueueSendToBackFromISR(evq->q, &tmp_ev, &woken2);
+      assert(ret == pdPASS);
+      woken |= woken2;
+    }
+
+    portYIELD_FROM_ISR(woken);
+  } else {
+    vPortEnterCritical();
+
+    count = uxQueueMessagesWaiting(evq->q);
+    for (i = 0; i < count; i++) {
+      ret = xQueueReceive(evq->q, &tmp_ev, 0);
+      assert(ret == pdPASS);
+
+      if (tmp_ev == ev) {
+        continue;
+      }
+
+      ret = xQueueSendToBack(evq->q, &tmp_ev, 0);
+      assert(ret == pdPASS);
+    }
+
+    vPortExitCritical();
+  }
+
+  ev->queued = 0;
+}
+
+ble_npl_error_t npl_pebble_mutex_init(struct ble_npl_mutex *mu) {
+  if (!mu) {
+    return BLE_NPL_INVALID_PARAM;
+  }
+
+  mu->handle = mutex_create_recursive();
+  assert(mu->handle);
+
+  return BLE_NPL_OK;
+}
+
+ble_npl_error_t npl_pebble_mutex_pend(struct ble_npl_mutex *mu, ble_npl_time_t timeout) {
+  if (!mu) {
+    return BLE_NPL_INVALID_PARAM;
+  }
+
+  assert(mu->handle);
+
+  if (mcu_state_is_isr()) {
+    WTF;
+  }
+
+  uint32_t ms;
+  ble_npl_time_ticks_to_ms(timeout, &ms);
+  return mutex_lock_recursive_with_timeout(mu->handle, ms) ? BLE_NPL_OK : BLE_NPL_TIMEOUT;
+}
+
+ble_npl_error_t npl_pebble_mutex_release(struct ble_npl_mutex *mu) {
+  if (!mu) {
+    return BLE_NPL_INVALID_PARAM;
+  }
+
+  assert(mu->handle);
+
+  mutex_unlock_recursive(mu->handle);
+
+  return BLE_NPL_OK;
+}
+
+ble_npl_error_t npl_pebble_sem_init(struct ble_npl_sem *sem, uint16_t tokens) {
+  if (!sem) {
+    return BLE_NPL_INVALID_PARAM;
+  }
+
+  sem->handle = xSemaphoreCreateCounting(128, tokens);
+  assert(sem->handle);
+
+  return BLE_NPL_OK;
+}
+
+ble_npl_error_t npl_pebble_sem_pend(struct ble_npl_sem *sem, ble_npl_time_t timeout) {
+  BaseType_t woken;
+  BaseType_t ret;
+
+  if (!sem) {
+    return BLE_NPL_INVALID_PARAM;
+  }
+
+  assert(sem->handle);
+
+  if (mcu_state_is_isr()) {
+    assert(timeout == 0);
+    ret = xSemaphoreTakeFromISR(sem->handle, &woken);
+    portYIELD_FROM_ISR(woken);
+  } else {
+    ret = xSemaphoreTake(sem->handle, timeout);
+  }
+
+  return ret == pdPASS ? BLE_NPL_OK : BLE_NPL_TIMEOUT;
+}
+
+ble_npl_error_t npl_pebble_sem_release(struct ble_npl_sem *sem) {
+  BaseType_t ret;
+  BaseType_t woken;
+
+  if (!sem) {
+    return BLE_NPL_INVALID_PARAM;
+  }
+
+  assert(sem->handle);
+
+  if (mcu_state_is_isr()) {
+    ret = xSemaphoreGiveFromISR(sem->handle, &woken);
+    portYIELD_FROM_ISR(woken);
+  } else {
+    ret = xSemaphoreGive(sem->handle);
+  }
+
+  assert(ret == pdPASS);
+  return BLE_NPL_OK;
+}
+
+static void os_callout_timer_cb(void *timer) {
+  struct ble_npl_callout *co = timer;
+
+  if (co->evq) {
+    ble_npl_eventq_put(co->evq, &co->ev);
+  } else {
+    co->ev.fn(&co->ev);
+  }
+}
+
+void npl_pebble_callout_init(struct ble_npl_callout *co, struct ble_npl_eventq *evq,
+                             ble_npl_event_fn *ev_cb, void *ev_arg) {
+  memset(co, 0, sizeof(*co));
+
+  co->handle = new_timer_create();
+  PBL_ASSERTN(co->handle != TIMER_INVALID_ID);
+  co->evq = evq;
+  co->ticks = 0;
+
+  ble_npl_event_init(&co->ev, ev_cb, ev_arg);
+}
+
+ble_npl_error_t npl_pebble_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks) {
+  new_timer_stop(co->handle);
+  uint32_t ms;
+  ble_npl_time_ticks_to_ms(ticks, &ms);
+  PBL_ASSERTN(new_timer_start(co->handle, ms, os_callout_timer_cb, co, 0));
+  co->ticks = ticks;
+  return BLE_NPL_OK;
+}
+
+void npl_pebble_callout_stop(struct ble_npl_callout *co) { new_timer_stop(co->handle); }
+
+bool npl_pebble_callout_is_active(struct ble_npl_callout *co) {
+  return new_timer_scheduled(co->handle, NULL);
+}
+
+ble_npl_time_t npl_pebble_callout_get_ticks(struct ble_npl_callout *co) { return co->ticks; }
+
+uint32_t npl_pebble_callout_remaining_ticks(struct ble_npl_callout *co, ble_npl_time_t now) {
+  uint32_t rt = 0;
+  new_timer_scheduled(co->handle, &rt);
+  return rt;
+}
+
+ble_npl_error_t npl_pebble_time_ms_to_ticks(uint32_t ms, ble_npl_time_t *out_ticks) {
+  uint64_t ticks;
+
+  ticks = milliseconds_to_ticks(ms);
+  if (ticks > UINT32_MAX) {
+    return BLE_NPL_EINVAL;
+  }
+
+  *out_ticks = ticks;
+
+  return 0;
+}
+
+ble_npl_error_t npl_pebble_time_ticks_to_ms(ble_npl_time_t ticks, uint32_t *out_ms) {
+  uint64_t ms;
+
+  ms = ticks_to_milliseconds(ticks);
+  if (ms > UINT32_MAX) {
+    return BLE_NPL_EINVAL;
+  }
+
+  *out_ms = ms;
+
+  return 0;
+}
+
+void __assert_func(const char *file, int line, const char *func, const char *e) {
+  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Nimble assert at line %d, func: %s - %s", line, func, e);
+  WTF;
+}

--- a/src/bluetooth-fw/nimble/reconnect.c
+++ b/src/bluetooth-fw/nimble/reconnect.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+void bt_driver_reconnect_pause(void) {}
+
+void bt_driver_reconnect_resume(void) {}
+
+void reconnect_set_interval(uint16_t new_interval) {}
+
+void bt_driver_reconnect_try_now(bool ignore_paused) {}
+
+void bt_driver_reconnect_reset_interval(void) {}
+
+void bt_driver_reconnect_notify_platform_bitfield(uint32_t platform_bitfield) {
+  // Don't care
+}

--- a/src/bluetooth-fw/nimble/responsiveness.c
+++ b/src/bluetooth-fw/nimble/responsiveness.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bluetooth/responsiveness.h"
+
+#include <inttypes.h>
+
+#include "bluetooth/gap_le_connect.h"
+
+bool bt_driver_le_connection_parameter_update(const BTDeviceInternal *addr,
+                                              const BleConnectionParamsUpdateReq *req) {
+  return true;
+}

--- a/src/bluetooth-fw/nimble/sniff.c
+++ b/src/bluetooth-fw/nimble/sniff.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+
+// FIXME: PBL-21106
+// Figure out what to do for our app_comm_get_sniff_interval() sniff API
+uint32_t sys_app_comm_get_sniff_interval(void) { return 0; }

--- a/src/bluetooth-fw/nimble/wscript
+++ b/src/bluetooth-fw/nimble/wscript
@@ -1,5 +1,10 @@
+def _recurse(ctx):
+    if ctx.env.bt_controller == 'cc2564x':
+        ctx.recurse('chipset/cc2564')
+
+
 def configure(conf):
-    pass
+    _recurse(conf)
 
 
 def build(bld):
@@ -23,6 +28,7 @@ def build(bld):
         f'{nimble_root}/nimble/transport/common/hci_h4/include',
         f'{nimble_root}/porting/nimble/include',
         f'{nimble_root}/ext/tinycrypt/include',
+        f'chipset/include',
         f'port/include',
         f'include',
     ]
@@ -80,7 +86,10 @@ def build(bld):
           'fw_includes',
           'freertos',
           'root_includes',
+          'bt_chipset_driver',
         ],
         includes=include_dirs,
         env = nimble_env,
     )
+
+    _recurse(bld)

--- a/src/bluetooth-fw/nimble/wscript
+++ b/src/bluetooth-fw/nimble/wscript
@@ -1,0 +1,14 @@
+def configure(conf):
+    pass
+
+
+def build(bld):
+    sources = bld.path.ant_glob('**/*.c')
+    bld.stlib(source=sources,
+              target='bt_driver',
+              defines=['FILE_LOG_COLOR=LOG_COLOR_BLUE'],
+              use=[
+                'fw_includes',
+                'freertos',
+                'root_includes',
+              ])

--- a/src/bluetooth-fw/nimble/wscript
+++ b/src/bluetooth-fw/nimble/wscript
@@ -3,12 +3,84 @@ def configure(conf):
 
 
 def build(bld):
-    sources = bld.path.ant_glob('**/*.c')
-    bld.stlib(source=sources,
-              target='bt_driver',
-              defines=['FILE_LOG_COLOR=LOG_COLOR_BLUE'],
-              use=[
-                'fw_includes',
-                'freertos',
-                'root_includes',
-              ])
+    nimble_root = bld.path.find_node('vendor/mynewt-nimble')
+
+    include_dirs = [
+        f'{nimble_root}/nimble/include',
+        f'{nimble_root}/nimble/host/include',
+        f'{nimble_root}/nimble/host/services/ans/include',
+        f'{nimble_root}/nimble/host/services/bas/include',
+        f'{nimble_root}/nimble/host/services/bleuart/include',
+        f'{nimble_root}/nimble/host/services/gap/include',
+        f'{nimble_root}/nimble/host/services/gatt/include',
+        f'{nimble_root}/nimble/host/services/ias/include',
+        f'{nimble_root}/nimble/host/services/dis/include',
+        f'{nimble_root}/nimble/host/services/lls/include',
+        f'{nimble_root}/nimble/host/services/tps/include',
+        f'{nimble_root}/nimble/host/store/ram/include',
+        f'{nimble_root}/nimble/host/util/include',
+        f'{nimble_root}/nimble/transport/include',
+        f'{nimble_root}/nimble/transport/common/hci_h4/include',
+        f'{nimble_root}/porting/nimble/include',
+        f'{nimble_root}/ext/tinycrypt/include',
+        f'port/include',
+        f'include',
+    ]
+
+    driver_source = bld.path.ant_glob([
+        '*.c',
+        'port/src/*.c',
+    ])
+
+    nimble_source_exclude = [
+        'nimble/host/src/ble_gatts_lcl.c', # has a duplicate define, not needed anyway
+        'porting/nimble/src/hal_timer.c',
+    ]
+    nimble_source_files = nimble_root.ant_glob(
+        [
+            'porting/nimble/src/*.c',
+            'nimble/src/*.c',
+            'nimble/host/src/*.c',
+            'nimble/host/util/src/*.c',
+            'nimble/host/services/gap/src/*.c',
+            'nimble/host/services/gatt/src/*.c',
+            'nimble/host/services/dis/src/*.c',
+            'nimble/host/store/ram/src/*.c',
+            'nimble/transport/src/*.c',
+            'nimble/transport/common/hci_h4/src/*.c',
+            'ext/tinycrypt/src/*.c',
+        ],
+        excl = nimble_source_exclude,
+    )
+
+    nimble_env = bld.env.derive()
+    nimble_env.append_value('CFLAGS', [
+        '-Wno-pointer-arith',
+        '-Wno-unused-function',
+        '-Wno-sign-compare',
+        '-Wno-old-style-declaration',
+        '-Wimplicit-fallthrough=1',
+    ])
+    nimble_env.append_value('DEFINES', [
+        'NIMBLE_BLE_SM=1',
+        'MYNEWT_VAL_BLE_SM_SC=1',
+        'MYNEWT_VAL_BLE_HS_AUTO_START=0',
+        'MYNEWT_VAL_BLE_SVC_DIS_MANUFACTURER_NAME_READ_PERM=0',
+        'MYNEWT_VAL_BLE_SVC_DIS_MODEL_NUMBER_READ_PERM=0',
+        'MYNEWT_VAL_BLE_SVC_DIS_SERIAL_NUMBER_READ_PERM=0',
+        'MYNEWT_VAL_BLE_SVC_DIS_FIRMWARE_REVISION_READ_PERM=0',
+        'MYNEWT_VAL_BLE_SVC_DIS_SOFTWARE_REVISION_READ_PERM=0',
+    ])
+
+    bld.objects(
+        source=driver_source + nimble_source_files,
+        target='bt_driver',
+        defines=['FILE_LOG_COLOR=LOG_COLOR_BLUE'],
+        use=[
+          'fw_includes',
+          'freertos',
+          'root_includes',
+        ],
+        includes=include_dirs,
+        env = nimble_env,
+    )

--- a/src/bluetooth-fw/wscript
+++ b/src/bluetooth-fw/wscript
@@ -13,8 +13,7 @@ def uses_dialog_bluetooth(ctx):
 
 def _recurse(ctx):
     if ctx.env.bt_controller == 'cc2564x':
-        # TODO: replace with real FW
-        ctx.recurse('stub')
+        ctx.recurse('nimble')
     elif ctx.uses_dialog_bluetooth():
         # TODO: replace with real FW
         ctx.recurse('stub')

--- a/src/fw/board/boards/board_snowy.c
+++ b/src/fw/board/boards/board_snowy.c
@@ -49,6 +49,7 @@ CREATE_DMA_STREAM(1, 3); // DMA1_STREAM3_DEVICE - Mic I2S RX
 CREATE_DMA_STREAM(1, 6); // DMA1_STREAM6_DEVICE - Accessory UART RX
 CREATE_DMA_STREAM(2, 0); // DMA2_STREAM0_DEVICE - Compositor DMA
 CREATE_DMA_STREAM(2, 5); // DMA2_STREAM5_DEVICE - ICE40LP TX
+CREATE_DMA_STREAM(2, 2); // DMA2_STREAM4_DEVICE - Bluetooth UART RX
 
 // DMA Requests
 
@@ -111,6 +112,16 @@ static DMARequest ICE40LP_SPI_TX_DMA_REQUEST = {
   .data_size = DMARequestDataSize_Byte,
 };
 
+static DMARequestState s_bluetooth_uart_rx_dma_request_state;
+static DMARequest BLUETOOTH_UART_RX_DMA_REQUEST = {
+  .state = &s_bluetooth_uart_rx_dma_request_state,
+  .stream = &DMA2_STREAM2_DEVICE,
+  .channel = 4,
+  .irq_priority = 0x0e,
+  .priority = DMARequestPriority_High,
+  .type = DMARequestType_PeripheralToMemory,
+  .data_size = DMARequestDataSize_Byte,
+};
 
 // UART DEVICES
 
@@ -171,6 +182,42 @@ static UARTDevice ACCESSORY_UART_DEVICE = {
 UARTDevice * const ACCESSORY_UART = &ACCESSORY_UART_DEVICE;
 IRQ_MAP(UART8, uart_irq_handler, ACCESSORY_UART);
 
+static UARTDeviceState s_bluetooth_uart_state;
+static UARTDevice BLUETOOTH_UART_DEVICE = {
+  .state = &s_bluetooth_uart_state,
+  .tx_gpio = {
+    .gpio = GPIOA,
+    .gpio_pin = GPIO_Pin_9,
+    .gpio_pin_source = GPIO_PinSource9,
+    .gpio_af = GPIO_AF_USART1
+  },
+  .rx_gpio = {
+    .gpio = GPIOA,
+    .gpio_pin = GPIO_Pin_10,
+    .gpio_pin_source = GPIO_PinSource10,
+    .gpio_af = GPIO_AF_USART1
+  },
+  .cts_gpio = {
+    .gpio = GPIOA,
+    .gpio_pin = GPIO_Pin_11,
+    .gpio_pin_source = GPIO_PinSource11,
+    .gpio_af = GPIO_AF_USART1
+  },
+  .rts_gpio = {
+    .gpio = GPIOA,
+    .gpio_pin = GPIO_Pin_12,
+    .gpio_pin_source = GPIO_PinSource12,
+    .gpio_af = GPIO_AF_USART1
+  },
+  .enable_flow_control = true,
+  .periph = USART1,
+  .irq_channel = USART1_IRQn,
+  .irq_priority = 0xe,
+  .rcc_apb_periph = RCC_APB2Periph_USART1,
+  // .rx_dma = &BLUETOOTH_UART_RX_DMA_REQUEST
+};
+UARTDevice * const BLUETOOTH_UART = &BLUETOOTH_UART_DEVICE;
+IRQ_MAP(USART1, uart_irq_handler, BLUETOOTH_UART);
 
 // I2C DEVICES
 

--- a/src/fw/board/boards/board_snowy.h
+++ b/src/fw/board/boards/board_snowy.h
@@ -255,6 +255,7 @@ extern DMARequest * const MIC_I2S_RX_DMA;
 extern UARTDevice * const QEMU_UART;
 extern UARTDevice * const DBG_UART;
 extern UARTDevice * const ACCESSORY_UART;
+extern UARTDevice * const BLUETOOTH_UART;
 
 extern SPISlavePort * const BMI160_SPI;
 

--- a/src/fw/board/boards/board_spalding_evt.c
+++ b/src/fw/board/boards/board_spalding_evt.c
@@ -49,6 +49,7 @@ CREATE_DMA_STREAM(1, 3); // DMA1_STREAM3_DEVICE - Mic I2S RX
 CREATE_DMA_STREAM(1, 6); // DMA1_STREAM6_DEVICE - Accessory UART RX
 CREATE_DMA_STREAM(2, 0); // DMA2_STREAM0_DEVICE - Compositor DMA
 CREATE_DMA_STREAM(2, 5); // DMA2_STREAM5_DEVICE - ICE40LP TX
+CREATE_DMA_STREAM(2, 2); // DMA2_STREAM4_DEVICE - Bluetooth UART RX
 
 // DMA Requests
 
@@ -111,6 +112,16 @@ static DMARequest ICE40LP_SPI_TX_DMA_REQUEST = {
   .data_size = DMARequestDataSize_Byte,
 };
 
+static DMARequestState s_bluetooth_uart_rx_dma_request_state;
+static DMARequest BLUETOOTH_UART_RX_DMA_REQUEST = {
+  .state = &s_bluetooth_uart_rx_dma_request_state,
+  .stream = &DMA2_STREAM2_DEVICE,
+  .channel = 4,
+  .irq_priority = 0x0e,
+  .priority = DMARequestPriority_High,
+  .type = DMARequestType_PeripheralToMemory,
+  .data_size = DMARequestDataSize_Byte,
+};
 
 // UART DEVICES
 
@@ -171,6 +182,42 @@ static UARTDevice ACCESSORY_UART_DEVICE = {
 UARTDevice * const ACCESSORY_UART = &ACCESSORY_UART_DEVICE;
 IRQ_MAP(UART8, uart_irq_handler, ACCESSORY_UART);
 
+static UARTDeviceState s_bluetooth_uart_state;
+static UARTDevice BLUETOOTH_UART_DEVICE = {
+  .state = &s_bluetooth_uart_state,
+  .tx_gpio = {
+    .gpio = GPIOA,
+    .gpio_pin = GPIO_Pin_9,
+    .gpio_pin_source = GPIO_PinSource9,
+    .gpio_af = GPIO_AF_USART1
+  },
+  .rx_gpio = {
+    .gpio = GPIOA,
+    .gpio_pin = GPIO_Pin_10,
+    .gpio_pin_source = GPIO_PinSource10,
+    .gpio_af = GPIO_AF_USART1
+  },
+  .cts_gpio = {
+    .gpio = GPIOA,
+    .gpio_pin = GPIO_Pin_11,
+    .gpio_pin_source = GPIO_PinSource11,
+    .gpio_af = GPIO_AF_USART1
+  },
+  .rts_gpio = {
+    .gpio = GPIOA,
+    .gpio_pin = GPIO_Pin_12,
+    .gpio_pin_source = GPIO_PinSource12,
+    .gpio_af = GPIO_AF_USART1
+  },
+  .enable_flow_control = true,
+  .periph = USART1,
+  .irq_channel = USART1_IRQn,
+  .irq_priority = 0xe,
+  .rcc_apb_periph = RCC_APB2Periph_USART1,
+  // .rx_dma = &BLUETOOTH_UART_RX_DMA_REQUEST
+};
+UARTDevice * const BLUETOOTH_UART = &BLUETOOTH_UART_DEVICE;
+IRQ_MAP(USART1, uart_irq_handler, BLUETOOTH_UART);
 
 // I2C DEVICES
 

--- a/src/fw/board/boards/board_spalding_evt.h
+++ b/src/fw/board/boards/board_spalding_evt.h
@@ -221,6 +221,7 @@ extern DMARequest * const MIC_I2S_RX_DMA;
 extern UARTDevice * const QEMU_UART;
 extern UARTDevice * const DBG_UART;
 extern UARTDevice * const ACCESSORY_UART;
+extern UARTDevice * const BLUETOOTH_UART;
 
 extern SPISlavePort * const BMI160_SPI;
 

--- a/src/fw/drivers/stm32f2/uart.c
+++ b/src/fw/drivers/stm32f2/uart.c
@@ -57,6 +57,11 @@ static void prv_init(UARTDevice *dev, bool is_open_drain, UARTCR1Flags cr1_extra
     PBL_ASSERTN(!dev->half_duplex);
     gpio_af_init(&dev->rx_gpio, otype, GPIO_Speed_50MHz, GPIO_PuPd_NOPULL);
   }
+  if (dev->enable_flow_control) {
+    PBL_ASSERTN(dev->cts_gpio.gpio && dev->rts_gpio.gpio);
+    gpio_af_init(&dev->cts_gpio, otype, GPIO_Speed_50MHz, GPIO_PuPd_NOPULL);
+    gpio_af_init(&dev->rts_gpio, otype, GPIO_Speed_50MHz, GPIO_PuPd_NOPULL);
+  }
 
   // configure the UART peripheral control registers
   // - 8-bit word length
@@ -67,6 +72,10 @@ static void prv_init(UARTDevice *dev, bool is_open_drain, UARTCR1Flags cr1_extra
   dev->periph->CR1 = cr1_extra_flags;
   dev->periph->CR2 = 0;
   dev->periph->CR3 = (dev->half_duplex ? USART_CR3_HDSEL : 0);
+
+  if (dev->enable_flow_control) {
+    dev->periph->CR3 |= USART_CR3_CTSE | USART_CR3_RTSE;
+  }
 
   // QEMU doesn't want you to read the DR while the UART is not enabled, but it
   // should be fine to clear errors this way

--- a/src/fw/drivers/stm32f2/uart_definitions.h
+++ b/src/fw/drivers/stm32f2/uart_definitions.h
@@ -38,8 +38,11 @@ typedef struct UARTState {
 typedef const struct UARTDevice {
   UARTDeviceState *state;
   bool half_duplex;
+  bool enable_flow_control;
   AfConfig tx_gpio;
   AfConfig rx_gpio;
+  AfConfig cts_gpio;
+  AfConfig rts_gpio;
   USART_TypeDef *periph;
   uint32_t rcc_apb_periph;
   uint8_t irq_channel;

--- a/src/fw/system/logging.h
+++ b/src/fw/system/logging.h
@@ -188,7 +188,7 @@ int pbl_log_get_bin_format(char* buffer, int buffer_len, const uint8_t log_level
   #define LOG_DOMAIN_BT_HCI           1
   #define LOG_DOMAIN_BT_SNIFF         1
 #else
-  #define LOG_DOMAIN_BT               0
+  #define LOG_DOMAIN_BT               1
 #endif
 
 #if LOG_DOMAIN_BT_PROFILES

--- a/src/fw/vendor/FreeRTOS/Source/include/semphr.h
+++ b/src/fw/vendor/FreeRTOS/Source/include/semphr.h
@@ -839,6 +839,18 @@ typedef QueueHandle_t SemaphoreHandle_t;
  */
 #define xSemaphoreGetMutexHolder( xSemaphore ) xQueueGetMutexHolder( ( xSemaphore ) )
 
+/**
+ * semphr.h
+ * <pre>UBaseType_t uxSemaphoreGetCount( SemaphoreHandle_t xSemaphore );</pre>
+ *
+ * If the semaphore is a counting semaphore then uxSemaphoreGetCount() returns
+ * its current count value.  If the semaphore is a binary semaphore then
+ * uxSemaphoreGetCount() returns 1 if the semaphore is available, and 0 if the
+ * semaphore is not available.
+ *
+ */
+#define uxSemaphoreGetCount( xSemaphore ) uxQueueMessagesWaiting( ( QueueHandle_t ) ( xSemaphore ) )
+
 #endif /* SEMAPHORE_H */
 
 

--- a/src/include/bluetooth/adv_reconnect.h
+++ b/src/include/bluetooth/adv_reconnect.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct GAPLEAdvertisingJobTerm GAPLEAdvertisingJobTerm;

--- a/waftools/cc2564_service_pack_convert.py
+++ b/waftools/cc2564_service_pack_convert.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import struct
+
+from resources.types.resource_definition import ResourceDefinition, StorageType
+from resources.types.resource_object import ResourceObject
+
+BTS_HEADER_STRUCT_FORMAT = '<HH'
+BTS_HEADER_STRUCT_SIZE = struct.calcsize(BTS_HEADER_STRUCT_FORMAT)
+BTS_ACTION_TYPE_HCI_COMMAND = 1
+
+# Strips out everything but the commands from the service pack
+def convert(bts_file_path):
+    resource_data = bytearray()
+    with open(bts_file_path, 'rb') as bts_file:
+        bts_file.seek(32) # skip header
+        while True:
+            bts_data = bts_file.read(BTS_HEADER_STRUCT_SIZE)
+            print(bts_data)
+            if not bts_data:
+                break
+
+            action_type, action_size = struct.unpack(BTS_HEADER_STRUCT_FORMAT, bts_data)
+            action_data = bts_file.read(action_size)
+            if action_type == BTS_ACTION_TYPE_HCI_COMMAND:
+                resource_data.extend(action_data)
+
+    return resource_data
+
+
+def wafrule(task):
+    data = convert(task.inputs[0].abspath())
+
+    if task.generator.bld.variant == 'prf':
+        storage = StorageType.builtin
+    else:
+        storage = StorageType.pbpack
+
+    reso = ResourceObject(ResourceDefinition('raw', 'BT_PATCH', None, storage=storage), data)
+    reso.dump(task.outputs[0])


### PR DESCRIPTION
There's enough here to:

- Integrate the NimBLE stack in the Pebble OS build
- Send the service pack to a CC2564B controller, with the pack bundled as a resource file (as used on snowy/spalding - if we eventually care about older devices those are pretty straightforward to add, code/resource size permitting)
- Get NimBLE to the point where we can start the stack and get the sync callback, and later stop the stack (eg, airplane mode toggle)

There's some hacks in here, eg we're not changing the UART speed, BT sleep modes are disabled and there's no DMA, but this seemed like a worthwhile milestone to share.

There's also a bug where we'll hit an assert inside the HCI frame parsing code sometimes I haven't gotten to the bottom of yet.

I have a commit for advertising ready to follow, and some changes to implement more of the missing APIs beyond that that need some more cleanup (eg, partially implementing the pairing service, GATT client API). I'll push those pieces up once this is submitted.