### PR TITLE
fw: ble: implement advertising support

### DIFF
--- a/src/bluetooth-fw/nimble/id.c
+++ b/src/bluetooth-fw/nimble/id.c
@@ -18,16 +18,24 @@
 #include <bluetooth/id.h>
 #include <string.h>
 
-void bt_driver_id_set_local_device_name(const char device_name[BT_DEVICE_NAME_BUFFER_SIZE]) {}
+#include "host/ble_hs_id.h"
+#include "services/gap/ble_svc_gap.h"
+#include "system/passert.h"
+
+void bt_driver_id_set_local_device_name(const char device_name[BT_DEVICE_NAME_BUFFER_SIZE]) {
+  int rc = ble_svc_gap_device_name_set(device_name);
+  PBL_ASSERTN(rc == 0);
+}
 
 void bt_driver_id_copy_local_identity_address(BTDeviceAddress *addr_out) {
-  memset(addr_out, 0xAA, sizeof(*addr_out));
+  int rc = ble_hs_id_copy_addr(BLE_ADDR_PUBLIC, (uint8_t *)&addr_out->octets, NULL);
+  PBL_ASSERTN(rc == 0);
 }
 
 void bt_driver_set_local_address(bool allow_cycling, const BTDeviceAddress *pinned_address) {}
 
 void bt_driver_id_copy_chip_info_string(char *dest, size_t dest_size) {
-  strncpy(dest, "QEMU", dest_size);
+  strncpy(dest, "NimBLE", dest_size);
 }
 
 bool bt_driver_id_generate_private_resolvable_address(BTDeviceAddress *address_out) {

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -75,9 +75,6 @@ void bt_driver_init(void) {
   s_host_stopped = xSemaphoreCreateBinary();
 
   nimble_port_init();
-  ble_svc_gap_init();
-  ble_svc_gatt_init();
-  ble_svc_dis_init();
   ble_store_ram_init();
 
   TaskParameters_t task_params = {
@@ -101,6 +98,10 @@ bool bt_driver_start(BTDriverConfig *config) {
   ble_svc_dis_firmware_revision_set(s_dis_info.fw_revision);
   ble_svc_dis_software_revision_set(s_dis_info.sw_revision);
   ble_svc_dis_manufacturer_name_set(s_dis_info.manufacturer);
+
+  ble_svc_gap_init();
+  ble_svc_gatt_init();
+  ble_svc_dis_init();
 
   ble_hs_sched_start();
   bool started = xSemaphoreTake(s_host_started,


### PR DESCRIPTION
This is enough to get Pebble advertising over BLE with all the device information set correctly. Note that the Pebble app won't see it because it only considers Pebble 2 when scanning BLE and this can't run on Pebble 2 yet.