### PR TITLE
fix: some cases where the correct stdint.h header file may not be found

### DIFF
--- a/tools/generate_native_sdk/parse_c_decl.py
+++ b/tools/generate_native_sdk/parse_c_decl.py
@@ -265,6 +265,7 @@ def parse_file(filename, filenames, func, internal_sdk_build=False, compiler_fla
     if not os.path.isfile(filename):
         raise Exception("Invalid filename: " + filename)
 
+    args.append("-ffreestanding")
     index = clang.cindex.Index.create()
     tu = index.parse(filename, args=args, options=clang.cindex.TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD)
 


### PR DESCRIPTION
In some environments, the parse_file function in the `tools/generate_native_sdk/parse_c_decl.py` script does not add the `-ffreestanding` parameter to the call to gcc, which results in the wrong header file being used by gcc