### PR TITLE
bluetooth-fw/nimble: do not stop adv if not active

### DIFF
--- a/src/bluetooth-fw/nimble/advert.c
+++ b/src/bluetooth-fw/nimble/advert.c
@@ -23,6 +23,10 @@
 void bt_driver_advert_advertising_disable(void) {
   int rc;
 
+  if (ble_gap_adv_active() == 0) {
+    return;
+  }
+
   rc = ble_gap_adv_stop();
   PBL_ASSERT(rc == 0, "Failed to stop advertising (%d)", rc);
 }


### PR DESCRIPTION
PebbleOS may try to stop advertising at times when NimBLE has already done that (e.g. when connected). Upper layer state machine may be corrected in the future if we converge to a single BLE host stack.