### PR TITLE
asterix: add some fake OTP / serial data until we have a real mfg flow

### DIFF
--- a/src/fw/drivers/nrf5/stubs/otp.c
+++ b/src/fw/drivers/nrf5/stubs/otp.c
@@ -22,7 +22,7 @@ uint8_t * otp_get_lock(const uint8_t index) {
 }
 
 bool otp_is_locked(const uint8_t index) {
-  return true;
+  return false;
 }
 
 OtpWriteResult otp_write_slot(const uint8_t index, const char *value) {

--- a/src/fw/mfg/asterix/mfg_info.c
+++ b/src/fw/mfg/asterix/mfg_info.c
@@ -46,7 +46,7 @@ static MfgData prv_fetch_struct(void) {
       break;
     default:
       // No data present, just return an initialized struct with default values.
-      return (MfgData) { .data_version = CURRENT_DATA_VERSION };
+      return (MfgData) { .data_version = CURRENT_DATA_VERSION, .color = WATCH_INFO_COLOR_PEBBLE_2_HR_BLACK, .model = "1002" /* SilkHR */ };
   }
 
   return result;

--- a/src/fw/mfg/mfg_serials.c
+++ b/src/fw/mfg/mfg_serials.c
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
+#include <stdio.h>
+
 #include "mfg_serials.h"
 
 #include "console/prompt.h"
 #include "util/size.h"
+
+#if MICRO_FAMILY_NRF5
+// HACK: see below
+#undef UNUSED
+#include <hal/nrf_ficr.h>
+#endif
 
 static const uint8_t OTP_SERIAL_SLOT_INDICES[] = {
     OTP_SERIAL1, OTP_SERIAL2, OTP_SERIAL3, OTP_SERIAL4, OTP_SERIAL5
@@ -41,6 +49,12 @@ static const char DUMMY_PCBA_SERIAL[MFG_PCBA_SERIAL_NUMBER_SIZE + 1] = "XXXXXXXX
 static void mfg_print_feedback(const MfgSerialsResult result, const uint8_t index, const char *value, const char *name);
 
 const char* mfg_get_serial_number(void) {
+#if MICRO_FAMILY_NRF5
+  // HACK: we don't have OTP storage on Asterix yet, so we make one up here using FICR.DEVICEID
+  static char nrf5_serial[MFG_SERIAL_NUMBER_SIZE + 1] = "_NRFXXXXXXXX";
+  snprintf(nrf5_serial, sizeof(nrf5_serial), "_NRF%08lx", nrf_ficr_deviceid_get(NRF_FICR, 0));
+  return nrf5_serial;
+#else
   // Trying from "most recent" slot to "least recent":
   for (int i = ARRAY_LENGTH(OTP_SERIAL_SLOT_INDICES) - 1; i >= 0; --i) {
     const uint8_t index = OTP_SERIAL_SLOT_INDICES[i];
@@ -49,6 +63,7 @@ const char* mfg_get_serial_number(void) {
     }
   }
   return DUMMY_SERIAL;
+#endif
 }
 
 const char* mfg_get_hw_version(void) {


### PR DESCRIPTION
The iOS app gets quite upset if there is no serial number or MFG data, and the current fake OTP data incorrectly reports that it is programmed already.  Later, we should implement OTP in terms of UICR (FIRM-35) but for now at least we should not report it as programmed if it is not.