### PR TITLE
fw: init PMIC before flash

### DIFF
--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -297,14 +297,14 @@ static void init_drivers(void) {
   accessory_init();
 #endif
 
+#if CAPABILITY_HAS_PMIC
+  pmic_init();
+#endif // CAPABILITY_HAS_PMIC
+
   flash_init();
   flash_sleep_when_idle(true);
   flash_enable_write_protection();
   flash_prf_set_protection(true);
-
-#if CAPABILITY_HAS_PMIC
-  pmic_init();
-#endif // CAPABILITY_HAS_PMIC
 
 #if CAPABILITY_HAS_MICROPHONE
   mic_init(MIC);


### PR DESCRIPTION
On nRF, PMIC powers flash, so flash_init() may fail on very first cold boot. This issue has likely been masked because we reset so often while debugging, and PMIC is never set into its reset state.

One day we need a proper driver architecture with dependency support etc. so we do not depend on fragile C code level ordering.