### PR TITLE
Fix bonding and reconnections for cc2564x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/pebble-dev/stm32-sdk.git
 [submodule "src/bluetooth-fw/nimble/vendor/mynewt-nimble"]
 	path = third_party/nimble/mynewt-nimble
-	url = https://github.com/apache/mynewt-nimble.git
+	url = https://github.com/pebble-dev/mynewt-nimble.git
 [submodule "src/bluetooth-fw/nimble/vendor/ti-service-packs"]
 	path = third_party/ti_bt_sp/ti-service-packs
 	url = https://git.ti.com/git/ti-bt/service-packs.git

--- a/src/fw/services/normal/bluetooth/bluetooth_persistent_storage.c
+++ b/src/fw/services/normal/bluetooth/bluetooth_persistent_storage.c
@@ -50,9 +50,10 @@
 // Let the unittest define this using a header override:
 #  include "services/normal/bluetooth/bluetooth_persistent_storage_unittest_impl.h"
 #else
-#  if BT_CONTROLLER_CC2564X
-#    include "services/normal/bluetooth/bluetooth_persistent_storage_v1_impl.h"
-#  elif BT_CONTROLLER_DA14681 || BT_CONTROLLER_QEMU || BT_CONTROLLER_NRF52
+// TODO: perhaps revert this back to v1 for cc2564x if we can figure out how to handle the old format
+// right now, you have to make sure you've erased all bondings before upgrading else you'll crash
+// because the v2 code chokes on the v1 format
+#  if BT_CONTROLLER_DA14681 || BT_CONTROLLER_QEMU || BT_CONTROLLER_NRF52 || BT_CONTROLLER_CC2564X
 #    include "services/normal/bluetooth/bluetooth_persistent_storage_v2_impl.h"
 #  else
 #    error "Unknown BT_CONTROLLER_... define?"

--- a/third_party/nimble/port/include/cc2564x/syscfg/syscfg.h
+++ b/third_party/nimble/port/include/cc2564x/syscfg/syscfg.h
@@ -871,6 +871,10 @@
 #define MYNEWT_VAL_BLE_RPA_TIMEOUT (300)
 #endif
 
+#ifndef MYNEWT_VAL_BLE_HOST_RPA_RESOLVER
+#define MYNEWT_VAL_BLE_HOST_RPA_RESOLVER (1)
+#endif
+
 /* Overridden by app (defined by @apache-mynewt-nimble/nimble/host) */
 #ifndef MYNEWT_VAL_BLE_SM_BONDING
 #define MYNEWT_VAL_BLE_SM_BONDING (1)

--- a/third_party/nimble/port/include/nrf52/syscfg/syscfg.h
+++ b/third_party/nimble/port/include/nrf52/syscfg/syscfg.h
@@ -2168,6 +2168,10 @@
 #define MYNEWT_VAL_BLE_RPA_TIMEOUT (300)
 #endif
 
+#ifndef MYNEWT_VAL_BLE_HOST_RPA_RESOLVER
+#define MYNEWT_VAL_BLE_HOST_RPA_RESOLVER (0)
+#endif
+
 /* Overridden by app (defined by @apache-mynewt-nimble/nimble/host) */
 #ifndef MYNEWT_VAL_BLE_SM_BONDING
 #define MYNEWT_VAL_BLE_SM_BONDING (1)

--- a/third_party/nimble/syscfg/targets/cc2564x/syscfg.yml
+++ b/third_party/nimble/syscfg/targets/cc2564x/syscfg.yml
@@ -14,3 +14,4 @@
 
 syscfg.vals:
     BLE_TRANSPORT_LL: socket
+    BLE_HOST_RPA_RESOLVER: 1


### PR DESCRIPTION
This appears to be needed on snowy even if it isn't needed on nrf: the LTK isn't the same for our/peer and if we return the wrong one the remote drops the connection.

I had to switch to the v2 bonding store format even though that wasn't previously used on CC2564x based devices. Bluetopia used ediv/div to store local encryption info, but Nimble uses ediv/rand/LTK and it seems to be non-trivial to adapt Nimble to use the Bluetopia stored values.

This is a bit of a problem because if you have bondings, the v2 code asserts when reading the bonding storage, but it's something I'll have to come back and fix later...