### PR TITLE
waftools: use `ccache` when available

### DIFF
--- a/waftools/pebble_arm_gcc.py
+++ b/waftools/pebble_arm_gcc.py
@@ -115,6 +115,9 @@ def configure(conf):
       conf.env.CC = find_clang_path(conf)
     else:
       conf.env.CC = CROSS_COMPILE_PREFIX + 'gcc'
+    conf.find_program('ccache', var='CCACHE', mandatory=False)
+    if conf.env.CCACHE:
+        conf.env.CC = [conf.env.CCACHE[0], conf.env.CC]
 
     conf.env.LINK_CC = conf.env.CC
 


### PR DESCRIPTION
Unfortunately `emcc` is not currently cacheable by `ccache` to my
knowledge, so this only helps with ~ 1000 / 1750 objects.

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>
