### PR TITLE
fw/flash_region: add flash region for GD25LQ255E

### DIFF
--- a/src/fw/flash_region/flash_region.h
+++ b/src/fw/flash_region/flash_region.h
@@ -35,8 +35,10 @@
   #endif
 
   #include "flash_region_n25q.h"
-#elif PLATFORM_SILK || PLATFORM_ASTERIX
+#elif PLATFORM_SILK
   #include "flash_region_mx25u.h"
+#elif PLATFORM_ASTERIX
+  #include "flash_region_gd25lq255e.h"
 #elif PLATFORM_CALCULUS || PLATFORM_ROBERT
   #include "flash_region_mt25q.h"
 #elif PLATFORM_SNOWY || PLATFORM_SPALDING

--- a/src/fw/flash_region/flash_region.h
+++ b/src/fw/flash_region/flash_region.h
@@ -16,43 +16,43 @@
 
 #pragma once
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #if PLATFORM_TINTIN
-  // v2_0 and v1_5 have 8MB flash chips instead of 4MB. In the following definition,
-  // BOARD_NOR_FLASH_SIZE is set to allow 6MB of the flash chip to be used. The extra 2MB tacked
-  // onto the end will be used for the filesystem and is being added to help with storing large
-  // language packs (ex. Chinese). If the entire 8MB needs to be used, this variable will have to
-  // be changed. Migrations are likely as well.
-  //
-  // On watches with only 4MB of flash, the region will have a size of zero and be ignored by the
-  // fileystem.
-  #if defined(BOARD_V2_0) || defined(BOARD_V1_5) || defined(LARGE_SPI_FLASH)
-    #define BOARD_NOR_FLASH_SIZE 0x600000
-  #else
-    #define BOARD_NOR_FLASH_SIZE 0x400000
-  #endif
+// v2_0 and v1_5 have 8MB flash chips instead of 4MB. In the following definition,
+// BOARD_NOR_FLASH_SIZE is set to allow 6MB of the flash chip to be used. The extra 2MB tacked
+// onto the end will be used for the filesystem and is being added to help with storing large
+// language packs (ex. Chinese). If the entire 8MB needs to be used, this variable will have to
+// be changed. Migrations are likely as well.
+//
+// On watches with only 4MB of flash, the region will have a size of zero and be ignored by the
+// fileystem.
+#if defined(BOARD_V2_0) || defined(BOARD_V1_5) || defined(LARGE_SPI_FLASH)
+#define BOARD_NOR_FLASH_SIZE 0x600000
+#else
+#define BOARD_NOR_FLASH_SIZE 0x400000
+#endif
 
-  #include "flash_region_n25q.h"
+#include "flash_region_n25q.h"
 #elif PLATFORM_SILK
-  #include "flash_region_mx25u.h"
+#include "flash_region_mx25u.h"
 #elif PLATFORM_ASTERIX
-  #include "flash_region_gd25lq255e.h"
+#include "flash_region_gd25lq255e.h"
 #elif PLATFORM_CALCULUS || PLATFORM_ROBERT
-  #include "flash_region_mt25q.h"
+#include "flash_region_mt25q.h"
 #elif PLATFORM_SNOWY || PLATFORM_SPALDING
-  #include "flash_region_s29vs.h"
+#include "flash_region_s29vs.h"
 #endif
 
 // NOTE: The following functions are deprecated! New code should use the
 // asynchronous version, flash_erase_optimal_range, in flash.h.
 
-//! Erase at least (max_start, min_end) but no more than (min_start, max_end) using as few erase operations
-//! as possible.
-//! (min_start, max_end) must be both 4kb aligned, as that's the smallest unit that we can erase.
-void flash_region_erase_optimal_range(uint32_t min_start, uint32_t max_start,
-                                      uint32_t min_end, uint32_t max_end);
+//! Erase at least (max_start, min_end) but no more than (min_start, max_end) using as few erase
+//! operations as possible. (min_start, max_end) must be both 4kb aligned, as that's the smallest
+//! unit that we can erase.
+void flash_region_erase_optimal_range(uint32_t min_start, uint32_t max_start, uint32_t min_end,
+                                      uint32_t max_end);
 
 //! The same as flash_region_erase_optimal_range but first disables the task watchdog for the
 //! current task.

--- a/src/fw/flash_region/flash_region_gd25lq255e.h
+++ b/src/fw/flash_region/flash_region_gd25lq255e.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#define PAGE_SIZE_BYTES (0x100)
+
+#define SECTOR_SIZE_BYTES (0x10000)
+#define SECTOR_ADDR_MASK (~(SECTOR_SIZE_BYTES - 1))
+
+#define SUBSECTOR_SIZE_BYTES (0x1000)
+#define SUBSECTOR_ADDR_MASK (~(SUBSECTOR_SIZE_BYTES - 1))
+
+// A bit of preprocessor magic to help with automatically calculating flash region addresses
+//////////////////////////////////////////////////////////////////////////////
+
+#define FLASH_REGION_DEF(MACRO, arg)                                                      \
+  MACRO(FIRMWARE_SCRATCH, 0x0100000 /*  1024k */, arg)        /*      0x0 - 0x0100000 */  \
+  MACRO(SYSTEM_RESOURCES_BANK_0, 0x0080000 /*   512K */, arg) /* 0x0100000 - 0x0180000 */ \
+  MACRO(SYSTEM_RESOURCES_BANK_1, 0x0080000 /*   512K */, arg) /* 0x0180000 - 0x0200000 */ \
+  MACRO(SAFE_FIRMWARE, 0x0080000 /*   512k */, arg)           /* 0x0200000 - 0x0280000 */ \
+  MACRO(DEBUG_DB, 0x0020000 /*   128k */, arg)                /* 0x0280000 - 0x02A0000 */ \
+  MACRO(FILESYSTEM, 0x1D50000 /* 30016k */, arg)              /* 0x02A0000 - 0x1FF0000 */ \
+  MACRO(RSVD, 0x000E000 /*    56k */, arg)                    /* 0x1FF0000 - 0x1FFE000 */ \
+  MACRO(SHARED_PRF_STORAGE, 0x0001000 /*     4k */, arg)      /* 0x1FFE000 - 0x1FFF000 */ \
+  MACRO(MFG_INFO, 0x0001000 /*     4k */, arg)                /* 0x1FFF000 - 0x2000000 */
+
+#include "flash_region_def_helper.h"
+
+// Flash region _BEGIN and _END addresses
+//////////////////////////////////////////////////////////////////////////////
+
+#define FLASH_REGION_FIRMWARE_SCRATCH_BEGIN FLASH_REGION_START_ADDR(FIRMWARE_SCRATCH)
+#define FLASH_REGION_FIRMWARE_SCRATCH_END FLASH_REGION_END_ADDR(FIRMWARE_SCRATCH)
+
+#define FLASH_REGION_SYSTEM_RESOURCES_BANK_0_BEGIN FLASH_REGION_START_ADDR(SYSTEM_RESOURCES_BANK_0)
+#define FLASH_REGION_SYSTEM_RESOURCES_BANK_0_END FLASH_REGION_END_ADDR(SYSTEM_RESOURCES_BANK_0)
+
+#define FLASH_REGION_SYSTEM_RESOURCES_BANK_1_BEGIN FLASH_REGION_START_ADDR(SYSTEM_RESOURCES_BANK_1)
+#define FLASH_REGION_SYSTEM_RESOURCES_BANK_1_END FLASH_REGION_END_ADDR(SYSTEM_RESOURCES_BANK_1)
+
+#define FLASH_REGION_SAFE_FIRMWARE_BEGIN FLASH_REGION_START_ADDR(SAFE_FIRMWARE)
+#define FLASH_REGION_SAFE_FIRMWARE_END FLASH_REGION_END_ADDR(SAFE_FIRMWARE)
+
+#define FLASH_REGION_DEBUG_DB_BEGIN FLASH_REGION_START_ADDR(DEBUG_DB)
+#define FLASH_REGION_DEBUG_DB_END FLASH_REGION_END_ADDR(DEBUG_DB)
+#define FLASH_DEBUG_DB_BLOCK_SIZE SUBSECTOR_SIZE_BYTES
+
+#define FLASH_REGION_FILESYSTEM_BEGIN FLASH_REGION_START_ADDR(FILESYSTEM)
+#define FLASH_REGION_FILESYSTEM_END FLASH_REGION_END_ADDR(FILESYSTEM)
+#define FLASH_FILESYSTEM_BLOCK_SIZE SUBSECTOR_SIZE_BYTES
+
+#define FLASH_REGION_SHARED_PRF_STORAGE_BEGIN FLASH_REGION_START_ADDR(SHARED_PRF_STORAGE)
+#define FLASH_REGION_SHARED_PRF_STORAGE_END FLASH_REGION_END_ADDR(SHARED_PRF_STORAGE)
+
+#define FLASH_REGION_MFG_INFO_BEGIN FLASH_REGION_START_ADDR(MFG_INFO)
+#define FLASH_REGION_MFG_INFO_END FLASH_REGION_END_ADDR(MFG_INFO)
+
+#define BOARD_NOR_FLASH_SIZE FLASH_REGION_START_ADDR(_COUNT)
+
+// Static asserts to make sure everything worked out
+//////////////////////////////////////////////////////////////////////////////
+
+// make sure all the sizes are multiples of the subsector size (4k)
+FLASH_REGION_SIZE_CHECK(SUBSECTOR_SIZE_BYTES)
+
+// make sure the PRF and MFG regions are within the last 64k sector so we can protect them.
+_Static_assert(FLASH_REGION_SHARED_PRF_STORAGE_BEGIN >= BOARD_NOR_FLASH_SIZE - SECTOR_SIZE_BYTES,
+               "Shared PRF storage should be within the last 64k of flash");
+_Static_assert(FLASH_REGION_MFG_INFO_BEGIN >= BOARD_NOR_FLASH_SIZE - SECTOR_SIZE_BYTES,
+               "MFG info should be within the last 64k of flash");
+
+// make sure the total size is what we expect (32mb)
+_Static_assert(BOARD_NOR_FLASH_SIZE == 0x2000000, "Flash size should be 32mb");


### PR DESCRIPTION
Until now Silk layout was used, so only 8MB were effectively available instead of 32MB.