### PR TITLE
adding python3-dev libpython3-dev to instructions

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -43,7 +43,7 @@ sudo apt update
 2. Install required dependencies
 
 ```shell
-sudo apt install gcc-multilib gettext python3-venv
+sudo apt install gcc-multilib gettext python3-venv python3-dev libpython3-dev 
 ```
 
 ::::


### PR DESCRIPTION
was getting an error, this fixed it. thanks @jwise 
```
  Building wheel for construct (pyproject.toml) ... done
  Created wheel for construct: filename=construct-2.5.3-py2.py3-none-any.whl size=71919 sha256=a7afa97b4bd92e03780e08e3d5fdce835fadae1ed57eb1460b194c509bd62aea
  Stored in directory: /home/eric/.cache/pip/wheels/c6/c2/8d/c1ce9602c5154430bcf28119b247f3fa359bab01faf9f6666d
Successfully built ply sh GitPython libpebble2 pebble.programmer pebble.commander pebble.pulse2 transitions pebble.loghash construct
Failed to build cobs
ERROR: Could not build wheels for cobs, which is required to install pyproject.toml-based projects
```