### PR TITLE
nRF QSPI fixes/improvements

### DIFF
--- a/python_libs/pebble-commander/pebble/commander/_commands/imaging.py
+++ b/python_libs/pebble-commander/pebble/commander/_commands/imaging.py
@@ -175,6 +175,9 @@ def _load(connection, image, progress, verbose, address):
     if verbose:
         print('Retries: %d' % retries)
 
+    if result_crc != image_crc:
+        print('CRC mismatch, got 0x%08X but expected %08X' % (result_crc, image_crc))
+
     return result_crc == image_crc
 
 

--- a/src/fw/drivers/nrf5/qspi.c
+++ b/src/fw/drivers/nrf5/qspi.c
@@ -118,13 +118,12 @@ bool qspi_flash_is_in_coredump_mode(QSPIFlash *dev) { return dev->state->coredum
 
 static void _flash_handler(nrfx_qspi_evt_t event, void *ctx) {
   QSPIFlash *dev = (QSPIFlash *)ctx;
+  BaseType_t woken = pdFALSE;
+
   PBL_ASSERTN(event == NRFX_QSPI_EVENT_DONE);
   dev->qspi->state->waiting = 0;
-  if (!dev->state->coredump_mode) {
-    BaseType_t woken = pdFALSE;
-    xSemaphoreGiveFromISR(dev->qspi->state->dma_semaphore, &woken);
-    portYIELD_FROM_ISR(woken);
-  }
+  xSemaphoreGiveFromISR(dev->qspi->state->dma_semaphore, &woken);
+  portYIELD_FROM_ISR(woken);
 }
 
 static void prv_configure_qe(QSPIFlash *dev) {

--- a/src/fw/drivers/nrf5/qspi.c
+++ b/src/fw/drivers/nrf5/qspi.c
@@ -19,6 +19,7 @@
 
 #define NRF5_COMPATIBLE
 #include <mcu.h>
+#include <nrfx.h>
 #include <nrfx_qspi.h>
 
 #include "FreeRTOS.h"
@@ -423,7 +424,7 @@ int qspi_flash_write_page_begin(QSPIFlash *dev, const void *buffer, uint32_t add
   const uint32_t offset_in_page = addr % PAGE_SIZE_BYTES;
   uint32_t bytes_in_page = MIN(PAGE_SIZE_BYTES - offset_in_page, length);
 
-  if (((uintptr_t)buffer & 0xF0000000) != 0x20000000) {
+  if (!nrfx_is_in_ram(buffer)) {
     /* we cannot DMA from non-RAM, so bounce through a RAM buffer if we have
      * to; this is not performant but it is ok because any time we are
      * writing to QSPI flash from internal flash, it is during

--- a/src/fw/drivers/nrf5/qspi.c
+++ b/src/fw/drivers/nrf5/qspi.c
@@ -435,9 +435,7 @@ int qspi_flash_write_page_begin(QSPIFlash *dev, const void *buffer, uint32_t add
 }
 
 status_t qspi_flash_get_write_status(QSPIFlash *dev) {
-  uint8_t status_reg;
-  prv_read_register(dev->qspi, dev->state->part->instructions.rdsr1, &status_reg, 1);
-  return (status_reg & dev->state->part->status_bit_masks.busy) ? E_BUSY : S_SUCCESS;
+  return nrfx_qspi_mem_busy_check() == NRFX_SUCCESS ? S_SUCCESS : E_BUSY;
 }
 
 void qspi_flash_set_lower_power_mode(QSPIFlash *dev, bool active) {

--- a/src/fw/drivers/nrf5/qspi.c
+++ b/src/fw/drivers/nrf5/qspi.c
@@ -184,7 +184,7 @@ void qspi_flash_init(QSPIFlash *dev, QSPIFlashPart *part, bool coredump_mode) {
   nrfx_qspi_config_t config = NRFX_QSPI_DEFAULT_CONFIG(
       dev->qspi->clk_gpio, dev->qspi->cs_gpio, dev->qspi->data_gpio[0], dev->qspi->data_gpio[1],
       dev->qspi->data_gpio[2], dev->qspi->data_gpio[3]);
-  config.phy_if.sck_freq = NRF_QSPI_FREQ_32MDIV1;
+  config.phy_if.sck_freq = NRF_QSPI_FREQ_32MDIV4;
 
   switch (dev->read_mode) {
     case QSPI_FLASH_READ_READ2O:

--- a/src/fw/drivers/nrf5/qspi.c
+++ b/src/fw/drivers/nrf5/qspi.c
@@ -30,6 +30,8 @@
 
 #define FLASH_RESET_WORD_VALUE (0xffffffff)
 
+static uint8_t s_qspi_ram_buffer[32];
+
 status_t flash_impl_set_nvram_erase_status(bool is_subsector, FlashAddress addr) {
   return S_SUCCESS;
 }
@@ -390,7 +392,6 @@ static void prv_write_page_begin(QSPIFlash *dev, const void *buffer, uint32_t ad
                dev->state->part->status_bit_masks.busy, false /* !set */, QSPI_NO_TIMEOUT);
 }
 
-static uint8_t s_qspi_ram_buffer[32];
 int qspi_flash_write_page_begin(QSPIFlash *dev, const void *buffer, uint32_t addr,
                                 uint32_t length) {
   const uint32_t offset_in_page = addr % PAGE_SIZE_BYTES;

--- a/src/fw/drivers/nrf5/qspi.c
+++ b/src/fw/drivers/nrf5/qspi.c
@@ -396,8 +396,6 @@ void qspi_flash_read_blocking(QSPIFlash *dev, uint32_t addr, void *buffer, uint3
 
 static void prv_write_page_begin(QSPIFlash *dev, const void *buffer, uint32_t addr,
                                  uint32_t length) {
-  PBL_ASSERTN(((uint32_t)buffer & 3) == 0);
-  PBL_ASSERTN(((uint32_t)buffer & 0xF0000000) == 0x20000000);
   PBL_ASSERTN(length > 0);
 
   prv_write_enable(dev);

--- a/src/fw/drivers/qspi_definitions.h
+++ b/src/fw/drivers/qspi_definitions.h
@@ -27,9 +27,6 @@
 
 typedef struct QSPIPortState {
   SemaphoreHandle_t dma_semaphore;
-#if MICRO_FAMILY_NRF5
-  volatile int waiting;
-#endif
   int use_count;
 } QSPIPortState;
 

--- a/src/fw/system/logging.h
+++ b/src/fw/system/logging.h
@@ -188,7 +188,7 @@ int pbl_log_get_bin_format(char* buffer, int buffer_len, const uint8_t log_level
   #define LOG_DOMAIN_BT_HCI           1
   #define LOG_DOMAIN_BT_SNIFF         1
 #else
-  #define LOG_DOMAIN_BT               1
+#define LOG_DOMAIN_BT 0
 #endif
 
 #if LOG_DOMAIN_BT_PROFILES


### PR DESCRIPTION
This PR resolves a long-standing issue with _long_ flash transfers leading to data corruption. It looks like it was mainly due to the flash clock speed being too high. For now, I've reduced flash clock from 32MHz to 8MHz. I guess 32MHz would require a better layout.

I have also taken the opportunity to do some cleanups to the nRF QSPI driver. Note that despite nRF PS claiming flash address needs to be word-aligned, this is not what I observe. Maybe some flash devices require word-aligned access (not GD25LQ255E), and this was incorrectly propagated to the PS.

I have also disabled BT logs by default, as they flood flash_logging when doing BLE file transfers, when you precisely want flash maximum bandwidth.

When flashing resources over pulse, the issue is never observed, however, when flashing recovery over pulse the issue can be observed from time to time.  When transferring data over BLE (e.g. fw updates) the issue happens every time.

I can confirm it is a data corruption issue because:
- Reading back written data shows data mismatch from time to time
- In the case above, I have observed:
  - Read back mismatch, but final transfer reports good CRC, meaning write succeeded but reads are randomly corrupted
  - Observing no read back mismatch, but final transfer reports CRC mismatch, again meaning write succeeded, but reads are randomly corrupted
  - Both, meaning write succeeded, but reads are randomly corrupted or write was also corrupted