### PR TITLE
bluetooth-fw: drop advert workaround APIs

### DIFF
--- a/docs/legacy/porting-bluetooth.md
+++ b/docs/legacy/porting-bluetooth.md
@@ -149,16 +149,6 @@ These apply only to Bluetooth Classic and are no-ops on BLE.
 * bt_driver_classic_pairability_set_enabled
 * sys_app_comm_get_sniff_interval
 
-### BLE advertisement bug workaround APIs.
-
-Bluetopia was buggy.  These APIs should be no-ops with a driver that doesn't
-need to be repeatedly kicked.
-
-* bt_driver_advert_is_connectable -- true
-* bt_driver_advert_client_has_cycled -- true
-* bt_driver_advert_client_set_cycled
-* bt_driver_advert_should_not_cycle -- false
-
 ### Analytics
 
 * bt_driver_analytics_get_connection_quality

--- a/src/bluetooth-fw/nimble/advert.c
+++ b/src/bluetooth-fw/nimble/advert.c
@@ -37,9 +37,6 @@ void bt_driver_advert_advertising_disable(void) {
   PBL_ASSERT(rc == 0, "Failed to stop advertising (%d)", rc);
 }
 
-// no impl needed for nimble, buggy stack workaround
-bool bt_driver_advert_is_connectable(void) { return true; }
-
 bool bt_driver_advert_client_get_tx_power(int8_t *tx_power) { return false; }
 
 void bt_driver_advert_set_advertising_data(const BLEAdData *ad_data) {
@@ -303,12 +300,3 @@ bool bt_driver_advert_advertising_enable(uint32_t min_interval_ms, uint32_t max_
 
   return true;
 }
-
-// no impl needed for nimble, buggy stack workaround
-bool bt_driver_advert_client_has_cycled(void) { return false; }
-
-// no impl needed for nimble, buggy stack workaround
-void bt_driver_advert_client_set_cycled(bool has_cycled) {}
-
-// no impl needed for nimble, buggy stack workaround
-bool bt_driver_advert_should_not_cycle(void) { return false; }

--- a/src/bluetooth-fw/qemu/advert.c
+++ b/src/bluetooth-fw/qemu/advert.c
@@ -19,10 +19,6 @@
 void bt_driver_advert_advertising_disable(void) {
 }
 
-bool bt_driver_advert_is_connectable(void) {
-  return false;
-}
-
 bool bt_driver_advert_client_get_tx_power(int8_t *tx_power) {
   return false;
 }
@@ -32,16 +28,5 @@ void bt_driver_advert_set_advertising_data(const BLEAdData *ad_data) {
 
 bool bt_driver_advert_advertising_enable(uint32_t min_interval_ms, uint32_t max_interval_ms,
                                      bool enable_scan_resp) {
-  return false;
-}
-
-bool bt_driver_advert_client_has_cycled(void) {
-  return false;
-}
-
-void bt_driver_advert_client_set_cycled(bool has_cycled) {
-}
-
-bool bt_driver_advert_should_not_cycle(void) {
   return false;
 }

--- a/src/bluetooth-fw/stub/advert.c
+++ b/src/bluetooth-fw/stub/advert.c
@@ -19,10 +19,6 @@
 void bt_driver_advert_advertising_disable(void) {
 }
 
-bool bt_driver_advert_is_connectable(void) {
-  return false;
-}
-
 bool bt_driver_advert_client_get_tx_power(int8_t *tx_power) {
   return false;
 }
@@ -32,16 +28,5 @@ void bt_driver_advert_set_advertising_data(const BLEAdData *ad_data) {
 
 bool bt_driver_advert_advertising_enable(uint32_t min_interval_ms, uint32_t max_interval_ms,
                                      bool enable_scan_resp) {
-  return false;
-}
-
-bool bt_driver_advert_client_has_cycled(void) {
-  return false;
-}
-
-void bt_driver_advert_client_set_cycled(bool has_cycled) {
-}
-
-bool bt_driver_advert_should_not_cycle(void) {
   return false;
 }

--- a/src/include/bluetooth/bt_driver_advert.h
+++ b/src/include/bluetooth/bt_driver_advert.h
@@ -29,13 +29,3 @@ void bt_driver_advert_advertising_disable(void);
 bool bt_driver_advert_client_get_tx_power(int8_t *tx_power);
 
 void bt_driver_advert_set_advertising_data(const BLEAdData *ad_data);
-
-// FIXME: These are ugly. They are used because of the workarounds with the TI chips.
-
-bool bt_driver_advert_is_connectable(void);
-
-bool bt_driver_advert_client_has_cycled(void);
-
-void bt_driver_advert_client_set_cycled(bool has_cycled);
-
-bool bt_driver_advert_should_not_cycle(void);


### PR DESCRIPTION
This code is currently causing issues on Asterix when tearing down the
system (assert). It doesn't seem to be necessary for Snowy under NimBLE.