### PR TITLE
Revert "ci: compliance: add clang-format check"

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -3,9 +3,6 @@ name: Compliance checks
 on:
   pull_request: {}
 
-env:
-  CLANG_FORMAT_VERSION: "20.1"
-
 jobs:
   lint:
     runs-on: ubuntu-24.04
@@ -16,11 +13,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Install dependencies
-        run: pip install gitlint clang-format~=${CLANG_FORMAT_VERSION}
+      - name: Install GitLint
+        run: pip install gitlint
 
       - name: Run GitLint 
         run: gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD"
-
-      - name: Run clang-format
-        run: git clang-format ${{ github.event.pull_request.base.sha }} --diff --verbose


### PR DESCRIPTION
This reverts commit e9d0ffdbf6fc342ef11abe4f4e0ec308c9b8f4f3.

Let's tune .clang-format, re-format the codebase and add this back.