### PR TITLE
bluetooth-fw: remove GATT MTU service

### DIFF
--- a/docs/legacy/porting-bluetooth.md
+++ b/docs/legacy/porting-bluetooth.md
@@ -86,7 +86,6 @@ See at least one implementation:
 https://github.com/pebble-dev/RebbleOS/blob/master/hw/drivers/nrf52_bluetooth/nrf52_bluetooth_ppogatt.c#L352-L417
 
 * bt_driver_pebble_pairing_service_handle_status_change
-* bt_driver_pebble_pairing_service_handle_gatt_mtu_change
 * bt_driver_cb_pebble_pairing_service_handle_connection_parameter_write
 * bt_driver_cb_pebble_pairing_service_handle_ios_app_termination_detected
 

--- a/src/bluetooth-fw/nimble/pebble_pairing_service.c
+++ b/src/bluetooth-fw/nimble/pebble_pairing_service.c
@@ -119,12 +119,6 @@ static int prv_access_trigger_pairing(uint16_t conn_handle, uint16_t attr_handle
   return 0;
 }
 
-static int prv_access_gatt_mtu(uint16_t conn_handle, uint16_t attr_handle,
-                               struct ble_gatt_access_ctxt *ctxt, void *arg) {
-  // TODO: implement
-  return 0;
-}
-
 static const struct ble_gatt_svc_def pebble_pairing_svc[] = {
     {
         .type = BLE_GATT_SVC_TYPE_PRIMARY,
@@ -142,12 +136,6 @@ static const struct ble_gatt_svc_def pebble_pairing_svc[] = {
                         BLE_UUID_SWIZZLE(PEBBLE_BT_PAIRING_SERVICE_TRIGGER_PAIRING_UUID)),
                     .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE,
                     .access_cb = prv_access_trigger_pairing,
-                },
-                {
-                    .uuid = BLE_UUID128_DECLARE(
-                        BLE_UUID_SWIZZLE(PEBBLE_BT_PAIRING_SERVICE_GATT_MTU_UUID)),
-                    .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_NOTIFY,
-                    .access_cb = prv_access_gatt_mtu,
                 },
                 {
                     0, /* No more characteristics in this service */
@@ -192,9 +180,4 @@ void bt_driver_pebble_pairing_service_handle_status_change(const GAPLEConnection
   prv_notify_chr_updated(
       connection,
       BLE_UUID128_DECLARE(BLE_UUID_SWIZZLE(PEBBLE_BT_PAIRING_SERVICE_CONNECTION_STATUS_UUID)));
-}
-
-void bt_driver_pebble_pairing_service_handle_gatt_mtu_change(const GAPLEConnection *connection) {
-  prv_notify_chr_updated(
-      connection, BLE_UUID128_DECLARE(BLE_UUID_SWIZZLE(PEBBLE_BT_PAIRING_SERVICE_GATT_MTU_UUID)));
 }

--- a/src/bluetooth-fw/qemu/pebble_pairing_service.c
+++ b/src/bluetooth-fw/qemu/pebble_pairing_service.c
@@ -18,6 +18,3 @@
 
 void bt_driver_pebble_pairing_service_handle_status_change(const GAPLEConnection *connection) {
 }
-
-void bt_driver_pebble_pairing_service_handle_gatt_mtu_change(const GAPLEConnection *connection) {
-}

--- a/src/bluetooth-fw/stub/pebble_pairing_service.c
+++ b/src/bluetooth-fw/stub/pebble_pairing_service.c
@@ -18,6 +18,3 @@
 
 void bt_driver_pebble_pairing_service_handle_status_change(const GAPLEConnection *connection) {
 }
-
-void bt_driver_pebble_pairing_service_handle_gatt_mtu_change(const GAPLEConnection *connection) {
-}

--- a/src/fw/comm/ble/gatt.c
+++ b/src/fw/comm/ble/gatt.c
@@ -71,13 +71,10 @@ void bt_driver_cb_gatt_handle_mtu_update(const GattDeviceMtuUpdateEvent *event) 
     if (!connection) {
       goto unlock;
     }
-    const bool has_mtu_changed = (connection->gatt_mtu != event->mtu);
+    
     PBL_LOG(LOG_LEVEL_DEBUG, "Handle MTU change from %d to %d bytes",
             connection->gatt_mtu, event->mtu);
-    if (has_mtu_changed) {
-      connection->gatt_mtu = event->mtu;
-    }
-    BLE_LOG_DEBUG("GATT MTU Updated: remote: %u", event->mtu);
+    connection->gatt_mtu = event->mtu;
   }
 unlock:
   bt_unlock();

--- a/src/fw/comm/ble/gatt.c
+++ b/src/fw/comm/ble/gatt.c
@@ -76,7 +76,6 @@ void bt_driver_cb_gatt_handle_mtu_update(const GattDeviceMtuUpdateEvent *event) 
             connection->gatt_mtu, event->mtu);
     if (has_mtu_changed) {
       connection->gatt_mtu = event->mtu;
-      bt_driver_pebble_pairing_service_handle_gatt_mtu_change(connection);
     }
     BLE_LOG_DEBUG("GATT MTU Updated: remote: %u", event->mtu);
   }

--- a/src/include/bluetooth/pebble_pairing_service.h
+++ b/src/include/bluetooth/pebble_pairing_service.h
@@ -22,7 +22,6 @@
 
 #define PEBBLE_BT_PAIRING_SERVICE_CONNECTION_STATUS_UUID PEBBLE_BT_UUID_EXPAND(1)
 #define PEBBLE_BT_PAIRING_SERVICE_TRIGGER_PAIRING_UUID PEBBLE_BT_UUID_EXPAND(2)
-#define PEBBLE_BT_PAIRING_SERVICE_GATT_MTU_UUID PEBBLE_BT_UUID_EXPAND(3)
 // Note: UUID 4 was used by the 3.14-rc Android App for V0 of the Connection Param characteristic
 // but never shipped externally
 #define PEBBLE_BT_PAIRING_SERVICE_CONNECTION_PARAMETERS_UUID PEBBLE_BT_UUID_EXPAND(5)
@@ -225,12 +224,6 @@ typedef struct GAPLEConnection GAPLEConnection;
 //! change.
 //! @param connection The connection for which the status was changed.
 void bt_driver_pebble_pairing_service_handle_status_change(const GAPLEConnection *connection);
-
-//! Signals to the Pebble GATT service the GATT MTU has changed, allowing it to notify any BLE
-//! devices that are subscribed to GATT MTU characteristic.
-//! @param connection The connection for which the GATT MTU has changed.
-//! @note the caller is responsible for taking bt_lock!
-void bt_driver_pebble_pairing_service_handle_gatt_mtu_change(const GAPLEConnection *connection);
 
 //! Indicate to the FW that Connectivity Status characteristic has been unsubscribed from.
 //! This is used to detect that the Pebble iOS app has been terminated.


### PR DESCRIPTION
Note that for now the preferred MTU stays at 256 (NimBLE default), increasing it requires to re-dimension buffers, it may be explored in the future.