### PR TITLE
pbltool: modernize for Python3

### DIFF
--- a/python_libs/pbl/pbl/__init__.py
+++ b/python_libs/pbl/pbl/__init__.py
@@ -3,9 +3,9 @@ import logging
 import pebble_tool
 from libpebble2.communication.transports.pulse import PULSETransport
 from libpebble2.exceptions import PebbleError
-from commands import coredump
-from commands import install_lang
-from commands import test
+from .commands import coredump
+from .commands import install_lang
+from .commands import test
 
 # TODO: unopened logging ports cause super noisy logs, fix this in the
 # pulse package then remove this

--- a/python_libs/pbl/pbl/commands/coredump.py
+++ b/python_libs/pbl/pbl/commands/coredump.py
@@ -36,7 +36,7 @@ class CoredumpCommand(PebbleCommand):
         self.progress_bar.finish()
 
         filename = self._generate_filename() if args.filename is None else args.filename
-        with open(filename, "w") as core_file:
+        with open(filename, "wb") as core_file:
             core_file.write(core_data)
         print("Saved coredump to {}".format(filename))
 


### PR DESCRIPTION
This also needs some changes elsewhere (in particular, it needs pebble-dev/libpebble2 in order to work right), but this is at least necessary if not sufficient to be able to pull a core dump over PULSE2.