### PR TITLE
console: add "flash stress" command that is somewhat more aggressive

### DIFF
--- a/src/fw/console/prompt_commands.h
+++ b/src/fw/console/prompt_commands.h
@@ -88,7 +88,7 @@ extern void command_flash_switch_mode(const char*);
 extern void command_flash_fill(const char*, const char*, const char*);
 extern void command_flash_test(const char* test_case_num_str, const char* iterations_str);
 extern void command_flash_test_locked_sectors(void);
-extern void command_flash_stress(void);
+extern void command_flash_stress(const char *);
 extern void command_flash_validate(void);
 extern void command_flash_apicheck(const char *len);
 extern void command_flash_unprotect(void);
@@ -632,8 +632,8 @@ static const Command s_prompt_commands[] = {
   // {"pfs stress", pfs_command_stress, 0 },
   {"pfs crc", pfs_command_crc, 1},
 
-  // This command is dangerous to your flash, so it is commented out by default.
-  // {"flash stress", command_flash_stress, 0 },
+  // This command is dangerous to your flash.  Be careful.
+  {"flash stress", command_flash_stress, 1 },
 #endif
 
   { "ping", command_ping_send, 0},


### PR DESCRIPTION
Previously, `prompt_commands` offered a `flash stress` that ran forever, but didn't check its work -- and continuously erased and re-erased sectors.  Also, it wrote to the log region, which was going to be used by other things!  It would be better to use as large of a region of flash as possible to write to, so we distribute the load -- and it would be nice to only erase when we have to, and to be able to check our work.

The new `flash stress` overwrites the update scratch region, and does a readback test, and uses a PRNG to compare repeatedly, and can test many different sizes and offsets of flash writes.  This `flash stress` can meaningfully find failures on asterix-evt1 when QSPI is run at 32MHz.