### PR TITLE
fw/services/data_logging: fix deadlock

### DIFF
--- a/src/fw/services/normal/data_logging/dls_endpoint.c
+++ b/src/fw/services/normal/data_logging/dls_endpoint.c
@@ -149,11 +149,15 @@ static void check_ack_timeout(void) {
 }
 
 static void ack_timer_cb(void *cb_data) {
+  dls_list_lock();
+
   mutex_lock(s_endpoint_data.mutex);
 
   check_ack_timeout();
 
   mutex_unlock(s_endpoint_data.mutex);
+
+  dls_list_unlock();
 }
 
 static bool find_soonest_ack_timeout_cb(DataLoggingSession *session, void *data) {

--- a/src/fw/services/normal/data_logging/dls_list.c
+++ b/src/fw/services/normal/data_logging/dls_list.c
@@ -327,6 +327,14 @@ DataLoggingSession *dls_list_get_next(DataLoggingSession *cur) {
   return logging_session;
 }
 
+void dls_list_lock(void) {
+  mutex_lock_recursive(s_list_mutex);
+}
+
+void dls_list_unlock(void) {
+  mutex_unlock_recursive(s_list_mutex);
+}
+
 bool dls_list_for_each_session(bool (callback(DataLoggingSession*, void*)), void *data) {
   mutex_lock_recursive(s_list_mutex);
   DataLoggingSession *logging_session = s_logging_sessions;

--- a/src/fw/services/normal/data_logging/dls_list.h
+++ b/src/fw/services/normal/data_logging/dls_list.h
@@ -77,3 +77,9 @@ DataLoggingStatus dls_get_session_status(DataLoggingSession *session);
 
 //! Assert that the current task owns the list mutex
 void dls_assert_own_list_mutex(void);
+
+//! Lock the list mutex (recursive lock).
+void dls_list_lock(void);
+
+//! Unlock the list mutex (recursive unlock)
+void dls_list_unlock(void);


### PR DESCRIPTION
It looks like DLS had a deadlock case between two recursive mutexes. Incidence seems to be _random_, but with current main high enough to freeze the watch just a few minutes after connecting to a phone. Below you will find a detailed analysis.

Tasks:
- `PebbleTask_KernelBackground`
- `PebbleTask_NewTimers`

Mutexes with circular dependency:
- `s_list_mutex` (`dls_list.c`)
- `s_endpoint_data.mutex` (`dls_endpoint.c`)

Measured condition:

```
! PebbleTask_KernelBackground [
  dls_list_for_each_session(callback=prv_send_session)
    mutex_lock_recursive: s_list_mutex
    prv_send_session
      dls_private_send_session
        dls_endpoint_send_data
	> PREEMPTION
	! PebbleTask_NewTimers [
	  ack_timer_cb
	    mutex_lock: s_endpoint_data.mutex
	    check_ack_timeout
              dls_list_for_each_session(
	        callback=check_ack_timeout_for_session
	      )
                mutex_lock_recursive: s_list_mutex
		!! DEADLOCK !!
		Task will be blocked here with s_list_mutex held by
		PebbleTask_KernelBackground
	]
          mutex_lock: s_endpoint_data.mutex
	  !! DEADLOCK !!
	  Task will be blocked here with s_endpoint_data.mutex held by
	  PebbleTask_NewTimers
]
```

The proposed patch breaks the circular mutex dependency by making sure `s_endpoint_data.mutex` is never acquired before `s_list_mutex` in `dls_endpoint.c`, so that `ack_timer_cb` will be held queued until `PebbleTask_KernelBackground` releases list access.

It is likely that some other issue has uncovered this bug, or that in old firmwares the chances to hit this were lower and so it was rarely or never observed. An alternative solution could be to check if `s_endpoint_data.mutex` locking scope could be reduced to prevent it from happening before `s_list_mutex`. I haven't checked if possible.