### PR TITLE
fw/apps/prf: center icon on asterix [FIRM-97]

### DIFF
--- a/src/fw/apps/prf_apps/recovery_first_use_app/recovery_first_use_app.c
+++ b/src/fw/apps/prf_apps/recovery_first_use_app/recovery_first_use_app.c
@@ -199,7 +199,7 @@ static void prv_update_background_image_and_url_text(RecoveryFUAppData *data) {
   }
 
   if (first_use_is_complete) {
-#if PBL_BW && !PLATFORM_TINTIN
+#if PBL_BW && !PLATFORM_TINTIN && !PLATFORM_ASTERIX
     // Override the icon to use the fullscreen version
     icon_res_id = RESOURCE_ID_LAUNCH_APP;
     icon_x_offset = 0;


### PR DESCRIPTION
PRF Icon offset was overriden to use a seperate fullscreen bitmap which isn't present on asterix, so this will just exclude it from the override restoring the centered icon in PRF