### PR TITLE
Add support for repeat pairing event

### DIFF
--- a/src/bluetooth-fw/nimble/advert.c
+++ b/src/bluetooth-fw/nimble/advert.c
@@ -94,9 +94,14 @@ static void prv_handle_connection_event(struct ble_gap_event *event) {
     key_sec.peer_addr = desc.peer_id_addr;
 
     rc = ble_store_read_peer_sec(&key_sec, &value_sec);
-    PBL_ASSERT(rc == 0, "Failed to read peer security (%d)", rc);
-
-    memcpy(complete_event.irk.data, value_sec.irk, 16);
+    if (rc != 0) {
+      // We can get a resolved address in case of a repeated pairing event,
+      // where peer security is deleted. An identity resolved event will be
+      // received later after the new pairing is completed.
+      complete_event.is_resolved = false;
+    } else {
+      memcpy(complete_event.irk.data, value_sec.irk, 16);
+    }
   } else {
     // If the address is not resolved, pairing is gonna happen.
     // Trigger name read to have it ready for the pairing confirmation.

--- a/src/fw/services/common/bluetooth/bluetooth_persistent_storage.h
+++ b/src/fw/services/common/bluetooth/bluetooth_persistent_storage.h
@@ -68,6 +68,8 @@ bool bt_persistent_storage_update_ble_device_name(BTBondingID bonding, const cha
 
 void bt_persistent_storage_delete_ble_pairing_by_id(BTBondingID);
 
+void bt_persistent_storage_delete_ble_pairing_by_addr(const BTDeviceInternal *device);
+
 bool bt_persistent_storage_get_ble_pairing_by_id(BTBondingID bonding,
                                                  SMIdentityResolvingKey *IRK_out,
                                                  BTDeviceInternal *device_out,

--- a/src/fw/services/prf/bluetooth/bluetooth_persistent_storage.c
+++ b/src/fw/services/prf/bluetooth/bluetooth_persistent_storage.c
@@ -149,6 +149,10 @@ void bt_persistent_storage_delete_ble_pairing_by_id(BTBondingID bonding) {
   prv_call_ble_bonding_change_handlers(bonding, BtPersistBondingOpWillDelete);
 }
 
+void bt_persistent_storage_delete_ble_pairing_by_addr(const BTDeviceInternal *device) {
+  bt_persistent_storage_delete_ble_pairing_by_id(BLE_BONDING_ID);
+}
+
 bool bt_persistent_storage_get_ble_pairing_by_id(BTBondingID bonding,
                                           SMIdentityResolvingKey *IRK_out,
                                           BTDeviceInternal *device_out,


### PR DESCRIPTION
If a phone deletes pairing information and watch is left in PRF mode
we won't be able to connect again because NimBLE doesn't handle the
repeat pairing event. While in normal firmware, we can always go to BT
settings menu and delete a pairing, we cannot in PRF. Ideally, we should
warn users about this event. This is left as a TODO for now.