### PR TITLE
fw/services/battery: do not trigger LP/critical states if plugged

### DIFF
--- a/src/fw/drivers/battery.h
+++ b/src/fw/drivers/battery.h
@@ -27,6 +27,14 @@
 
 void battery_init(void);
 
+/**
+ * Check if the battery is present.
+ *
+ * @retval true if the battery is present (or driver does not support checking).
+ * @retval false if the battery is not present.
+*/
+bool battery_is_present(void);
+
 /** @returns the battery voltage after smoothing and averaging
  */
 int battery_get_millivolts(void);

--- a/src/fw/drivers/battery/battery_pmic.c
+++ b/src/fw/drivers/battery/battery_pmic.c
@@ -27,6 +27,10 @@ void battery_init(void) {
   return;
 }
 
+bool battery_is_present(void) {
+  return true;
+}
+
 int battery_get_millivolts(void) {
   if (!pmic_enable_battery_measure()) {
     PBL_LOG(LOG_LEVEL_WARNING, "Failed to enable battery measure. "

--- a/src/fw/drivers/battery/battery_tintin.c
+++ b/src/fw/drivers/battery/battery_tintin.c
@@ -204,6 +204,10 @@ static void battery_vusb_interrupt_handler(bool *should_context_switch) {
   system_task_add_callback_from_isr(prv_start_timer_sys_task_callback, NULL, should_context_switch);
 }
 
+bool battery_is_present(void) {
+  return true;
+}
+
 int battery_get_millivolts(void) {
   ADCVoltageMonitorReading info = battery_read_voltage_monitor();
 

--- a/src/fw/drivers/pmic/npm1300.c
+++ b/src/fw/drivers/pmic/npm1300.c
@@ -35,6 +35,7 @@ typedef enum {
   PmicRegisters_BCHARGER_BCHGENABLESET = 0x0304,
   PmicRegisters_BCHARGER_BCHGENABLECLR = 0x0305,
   PmicRegisters_BCHARGER_BCHGCHARGESTATUS = 0x0334,
+  PmicRegisters_BCHARGER_BCHGCHARGESTATUS__BATTERYDETECTED = 1,
   PmicRegisters_BCHARGER_BCHGCHARGESTATUS__COMPLETED = 2,
   PmicRegisters_BCHARGER_BCHGCHARGESTATUS__TRICKLECHARGE = 4,
   PmicRegisters_BCHARGER_BCHGCHARGESTATUS__CONSTANTCURRENT = 8,
@@ -213,6 +214,14 @@ uint16_t pmic_get_vsys(void) {
   uint32_t vsys = vsys_raw * 6375 / 1023;
   
   return vsys;
+}
+
+bool battery_is_present(void) {
+  uint8_t reg = 0;
+  if (!prv_read_register(PmicRegisters_BCHARGER_BCHGCHARGESTATUS, &reg)) {
+    return false;
+  }
+  return (reg & PmicRegisters_BCHARGER_BCHGCHARGESTATUS__BATTERYDETECTED) != 0;
 }
 
 int battery_get_millivolts(void) {

--- a/src/fw/drivers/qemu/qemu_battery.c
+++ b/src/fw/drivers/qemu/qemu_battery.c
@@ -34,6 +34,10 @@ void battery_init(void) {
   s_usb_connected = qemu_setting_get(QemuSetting_DefaultPluggedIn);
 }
 
+bool battery_is_present(void) {
+  return true;
+}
+
 // TODO: update whoever uses this function
 int battery_get_millivolts(void) {
   return s_battery_mv;

--- a/src/fw/services/common/battery/battery_monitor.c
+++ b/src/fw/services/common/battery/battery_monitor.c
@@ -183,12 +183,14 @@ void battery_monitor_handle_state_change_event(PreciseBatteryChargeState state) 
   //  Similarly, if the battery voltage has rebounded when the timer expires, the shutdown
   //    will not occur.
 
-  bool critical = (state.charge_percent == 0) && !state.is_charging;
+  bool critical = (state.charge_percent == 0 && state.is_present) && !state.is_charging;
+;
 
 #ifndef RECOVERY_FW
   const uint32_t LOW_POWER_PERCENT = ratio32_from_percent(BOARD_CONFIG_POWER.low_power_threshold);
 
-  bool low_power = !state.is_charging && (state.charge_percent <= LOW_POWER_PERCENT);
+  bool low_power = !state.is_charging && !state.is_plugged &&
+                   (state.charge_percent <= LOW_POWER_PERCENT && state.is_present);
   s_low_on_first_run = s_low_on_first_run || (low_power && s_first_run);
 #else
   const uint32_t PRF_LOW_POWER_THRESHOLD_PERCENT = ratio32_from_percent(5);

--- a/src/fw/services/common/battery/battery_state.c
+++ b/src/fw/services/common/battery/battery_state.c
@@ -61,6 +61,7 @@ static const ConnectionState s_transitions[] = {
 };
 
 typedef struct BatteryState {
+  bool present;
   uint64_t init_time;
   uint32_t percent;
   uint16_t voltage;
@@ -235,6 +236,9 @@ static void prv_update_state(void *force_update) {
       charging || state_changed) {
     battery_state_put_change_event(prv_get_precise_charge_state(&s_last_battery_state));
   }
+
+  // Update battery presency status
+  s_last_battery_state.present = battery_is_present();
 }
 
 static void prv_update_callback(void *data) {
@@ -286,7 +290,8 @@ PreciseBatteryChargeState prv_get_precise_charge_state(const BatteryState *state
   PreciseBatteryChargeState event_state = {
     .charge_percent = state->percent,
     .is_charging = (s_last_battery_state.connection == ConnectionStateChargingPlugged),
-    .is_plugged = (s_last_battery_state.connection != ConnectionStateDischargingUnplugged)
+    .is_plugged = (s_last_battery_state.connection != ConnectionStateDischargingUnplugged),
+    .is_present = s_last_battery_state.present,
   };
   return event_state;
 }

--- a/src/fw/services/common/battery/battery_state.h
+++ b/src/fw/services/common/battery/battery_state.h
@@ -53,6 +53,7 @@ typedef struct {
   //! the user-facing defintion of whether we're charging (100% battery).
   bool is_charging;
   bool is_plugged;
+  bool is_present;
 } PreciseBatteryChargeState;
 
 //! Function to get the current battery charge state


### PR DESCRIPTION
Regardless of the battery state, stay in good state if the watch is plugged. This can happen e.g. in development where the battery is in reality a power source that can be turned off if operating from VUSB only. In a real watch, this will just happen if battery is completely dead, but still, allow using the watch if plugged. Nordic PMIC will by default not even try to charge a battery like that. If this is a safety concern for older designs this can be made configurable.