### PR TITLE
asterix: work around busted LFXOs on some evt2s by increasing SCA tolerance

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -7,3 +7,6 @@ ignore-squash-commits=false
 
 [title-match-regex]
 regex=[a-z0-9/]+: .*
+
+[title-max-length]
+line-length=100

--- a/src/fw/drivers/nrf5/rtc.c
+++ b/src/fw/drivers/nrf5/rtc.c
@@ -315,6 +315,22 @@ void rtc_init(void) {
 
   nrf_rtc_prescaler_set(BOARD_RTC_INST, NRF_RTC_FREQ_TO_PRESCALER(RTC_TICKS_HZ));
   nrf_rtc_task_trigger(BOARD_RTC_INST, NRF_RTC_TASK_START);
+
+#if TEST_RTC_FREQ
+  // FIXME: can be removed after FIRM-121 is fixed
+  extern void board_early_init();
+  board_early_init();
+  for (int i = 0; i < 100; i++) {
+    uint32_t ctr0 = nrf_rtc_counter_get(BOARD_RTC_INST);
+    while (nrf_rtc_counter_get(BOARD_RTC_INST) == ctr0)
+      ;
+    ctr0 = nrf_rtc_counter_get(BOARD_RTC_INST) + 100;
+    uint32_t iters = 0;
+    while (nrf_rtc_counter_get(BOARD_RTC_INST) != ctr0)
+      iters++;
+    PBL_LOG(LOG_LEVEL_INFO, "RTC: 100 RTC ticks took %"PRIu32" iters", iters);
+  }
+#endif
   
   prv_restore_rtc_time_state();
   s_did_init_rtc = true;

--- a/third_party/nimble/port/include/nrf52/syscfg/syscfg.h
+++ b/third_party/nimble/port/include/nrf52/syscfg/syscfg.h
@@ -1752,7 +1752,7 @@
 
 /* Value copied from BLE_LL_OUR_SCA */
 #ifndef MYNEWT_VAL_BLE_LL_SCA
-#define MYNEWT_VAL_BLE_LL_SCA (60)
+#define MYNEWT_VAL_BLE_LL_SCA (500)
 #endif
 
 /* Value copied from BLE_LL_CFG_FEAT_LL_PRIVACY */

--- a/third_party/nimble/syscfg/targets/nrf52/syscfg.yml
+++ b/third_party/nimble/syscfg/targets/nrf52/syscfg.yml
@@ -24,3 +24,5 @@ syscfg.vals:
     BLE_SM_LEGACY: 0
     BLE_SM_MITM: 1
     BLE_SM_LVL: 4
+    # TODO: put this back in production [FIRM-121]
+    BLE_LL_SCA: 500


### PR DESCRIPTION
Some evt2s appear to have an LFXO that is off by as much as 350ppm, as measured on a scope, or more, if measured with LFSYNTH vs. LFXTAL; this causes BLE to fail to connect.  Work around this until such time as the hardware is fixed for certain.