### PR TITLE
fw/drivers/display: add missing include

### DIFF
--- a/src/fw/drivers/display/display.h
+++ b/src/fw/drivers/display/display.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "board/display.h"
+#include "applib/graphics/gtypes.h"
 
 #include <stdint.h>
 #include <stdbool.h>


### PR DESCRIPTION
display.h uses `struct GPoint`, but it does not include its definition header. Things likely worked because of indirect include chain. This likely needs a proper cleanup, but allows to compile for now.