### PR TITLE
fw/apps/alarm_editor: add missing include

### DIFF
--- a/src/fw/apps/system_apps/alarms/alarm_editor.c
+++ b/src/fw/apps/system_apps/alarms/alarm_editor.c
@@ -31,6 +31,7 @@
 #include "services/normal/alarms/alarm.h"
 #include "system/logging.h"
 #include "system/passert.h"
+#include "util/size.h"
 
 #include <string.h>
 


### PR DESCRIPTION
For ARRAY_LENGTH(), this worked because... board files included it!