### PR TITLE
fw: move vector table section into every soc file

### DIFF
--- a/src/fw/fw_common.ld
+++ b/src/fw/fw_common.ld
@@ -89,12 +89,6 @@ We take that image and load part of it into RAM. That lay out looks like...
 */
 
 SECTIONS {
-    .isr_vector : {
-        ASSERT(. == ORIGIN(FLASH), "Error: Vector table is offset from the start of the FLASH region");
-        PROVIDE(__ISR_VECTOR_TABLE__ = .);
-        KEEP(*(.isr_vector))            /* Startup code */
-    } >FLASH
-
     /* Exception handling sections. "contains index entries for section unwinding"
      * We don't actually use this or know what it is, but it seems happy to go here. */
     .ARM.exidx :

--- a/src/fw/nrf52840_flash_fw.ld.template
+++ b/src/fw/nrf52840_flash_fw.ld.template
@@ -13,6 +13,12 @@ MEMORY
 
 SECTIONS
 {
+    .isr_vector : {
+        ASSERT(. == ORIGIN(FLASH), "Error: Vector table is offset from the start of the FLASH region");
+        PROVIDE(__ISR_VECTOR_TABLE__ = .);
+        KEEP(*(.isr_vector))
+    } >FLASH
+
     .retained : ALIGN(4) {
         __retained_start = .;
         *(.retained)

--- a/src/fw/stm32f2xx_flash_fw.ld.template
+++ b/src/fw/stm32f2xx_flash_fw.ld.template
@@ -18,3 +18,10 @@ REGION_ALIAS("REGION_KERNEL_HEAP", KERNEL_RAM);
 
 @BOOTLOADER_SYMBOLS@
 
+SECTIONS {
+    .isr_vector : {
+        ASSERT(. == ORIGIN(FLASH), "Error: Vector table is offset from the start of the FLASH region");
+        PROVIDE(__ISR_VECTOR_TABLE__ = .);
+        KEEP(*(.isr_vector))
+    } >FLASH
+}

--- a/src/fw/stm32f412_flash_fw.ld.template
+++ b/src/fw/stm32f412_flash_fw.ld.template
@@ -16,3 +16,10 @@ REGION_ALIAS("REGION_ISR_STACK", KERNEL_RAM);
 REGION_ALIAS("REGION_KERNEL_STACKS", KERNEL_RAM);
 REGION_ALIAS("REGION_KERNEL_HEAP", KERNEL_RAM);
 
+SECTIONS {
+    .isr_vector : {
+        ASSERT(. == ORIGIN(FLASH), "Error: Vector table is offset from the start of the FLASH region");
+        PROVIDE(__ISR_VECTOR_TABLE__ = .);
+        KEEP(*(.isr_vector))
+    } >FLASH
+}

--- a/src/fw/stm32f439_flash_fw.ld.template
+++ b/src/fw/stm32f439_flash_fw.ld.template
@@ -20,3 +20,11 @@ __CCM_RAM_size__ = LENGTH(CCM);
 REGION_ALIAS("REGION_ISR_STACK", KERNEL_RAM);
 REGION_ALIAS("REGION_KERNEL_STACKS", CCM);
 REGION_ALIAS("REGION_KERNEL_HEAP", CCM);
+
+SECTIONS {
+    .isr_vector : {
+        ASSERT(. == ORIGIN(FLASH), "Error: Vector table is offset from the start of the FLASH region");
+        PROVIDE(__ISR_VECTOR_TABLE__ = .);
+        KEEP(*(.isr_vector))
+    } >FLASH
+}

--- a/src/fw/stm32f7xx_flash_fw.ld.template
+++ b/src/fw/stm32f7xx_flash_fw.ld.template
@@ -32,6 +32,12 @@ REGION_ALIAS("REGION_KERNEL_HEAP", KERNEL_RAM);
 
 SECTIONS
 {
+    .isr_vector : {
+        ASSERT(. == ORIGIN(FLASH), "Error: Vector table is offset from the start of the FLASH region");
+        PROVIDE(__ISR_VECTOR_TABLE__ = .);
+        KEEP(*(.isr_vector))
+    } >FLASH
+
     .dtcm_bss (NOLOAD) : {
         __dtcm_bss_start = .;
 


### PR DESCRIPTION
If any SoC adds a new section to flash, it will get the first offset, triggering the ISR vector section assert. None of the existing SoCs needed to add new sections, so it has been ok to keep the entry in the common file until now. However, SF32LB will need to add an extra entry that triggers this problem. If we ever preprocess the ld files, or generate them in a more advanced manner, we could improve this, but now I do not see any other immediate solution (maybe I'm just tired).