### PR TITLE
third_party: nimble: Fix use of stack-allocated variable

### DIFF
--- a/third_party/nimble/transport/chipset/cc2564.c
+++ b/third_party/nimble/transport/chipset/cc2564.c
@@ -71,7 +71,7 @@ static bool ble_run_bts(const ResAppNum bts_file) {
 
     if (command->opcode == HCI_VS_UPDATE_UART_HCI_BAUDRATE) {
       PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_INFO, "ble_bts: Setting baud rate to %d", HCI_BAUD_RATE);
-      BTSHCIUpdateBaudRateCommand baud_rate_command = {
+      static BTSHCIUpdateBaudRateCommand baud_rate_command = {
           .opcode = HCI_VS_UPDATE_UART_HCI_BAUDRATE,
           .size = sizeof(uint32_t),
           .type = HCI_H4_CMD,


### PR DESCRIPTION
The `baud_rate_command` was allocated on the stack and assigned to a pointer used after the block ended, leading to undefined behavior, i.e. the HCI_VS_UPDATE_UART_HCI_BAUDRATE command was randomly not sent at all. Made the variable static to ensure it persists beyond the block.