### PR TITLE
nimble/cc2564x: turn on flow control for HCI

### DIFF
--- a/third_party/nimble/port/include/cc2564x/syscfg/syscfg.h
+++ b/third_party/nimble/port/include/cc2564x/syscfg/syscfg.h
@@ -18,7 +18,7 @@
 
 /*** Repository @apache-mynewt-core info */
 #ifndef MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_CORE
-#define MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_CORE "7a30a7a901136d55ccb10b1a55ff7effcc640605"
+#define MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_CORE "b3506365790c44d87685fe0dfb290fdccc89e6d2"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_APACHE_MYNEWT_CORE
@@ -27,7 +27,7 @@
 
 /*** Repository @apache-mynewt-nimble info */
 #ifndef MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_NIMBLE
-#define MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_NIMBLE "7b14eab3d07caffa3a70046271b9f5b805f5c965-dirty"
+#define MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_NIMBLE "a6b2f3f9af8b7b46f51f3af3a89d656dffd9483e"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_APACHE_MYNEWT_NIMBLE
@@ -36,16 +36,16 @@
 
 /*** Repository @mcuboot info */
 #ifndef MYNEWT_VAL_REPO_HASH_MCUBOOT
-#define MYNEWT_VAL_REPO_HASH_MCUBOOT "9c99326b9756dbcc35b524636d99ed5f3e6cb29b"
+#define MYNEWT_VAL_REPO_HASH_MCUBOOT "2d61c318933819a0f4954fb2a5a957a62c6128ce"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_MCUBOOT
-#define MYNEWT_VAL_REPO_VERSION_MCUBOOT "2.1.0"
+#define MYNEWT_VAL_REPO_VERSION_MCUBOOT "2.2.0"
 #endif
 
 /*** Repository @syscfg info */
 #ifndef MYNEWT_VAL_REPO_HASH_SYSCFG
-#define MYNEWT_VAL_REPO_HASH_SYSCFG "a9e189376ac42b09e9c85459393c5957497cef79-dirty"
+#define MYNEWT_VAL_REPO_HASH_SYSCFG "1a2fbfa2b2aa656237c36a4fac5715fa0c3670e6-dirty"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_SYSCFG
@@ -139,10 +139,12 @@
 #define MYNEWT_VAL_FLOAT_USER (0)
 #endif
 
+/* Overridden by targets/cc2564x (defined by @apache-mynewt-core/kernel/os) */
 #ifndef MYNEWT_VAL_MSYS_1_BLOCK_COUNT
 #define MYNEWT_VAL_MSYS_1_BLOCK_COUNT (35)
 #endif
 
+/* Overridden by targets/cc2564x (defined by @apache-mynewt-core/kernel/os) */
 #ifndef MYNEWT_VAL_MSYS_1_BLOCK_SIZE
 #define MYNEWT_VAL_MSYS_1_BLOCK_SIZE (304)
 #endif
@@ -694,6 +696,7 @@
 #define MYNEWT_VAL_BLE_GATT_INDICATE (1)
 #endif
 
+/* Overridden by targets/cc2564x (defined by @apache-mynewt-nimble/nimble/host) */
 #ifndef MYNEWT_VAL_BLE_GATT_MAX_PROCS
 #define MYNEWT_VAL_BLE_GATT_MAX_PROCS (8)
 #endif
@@ -762,6 +765,11 @@
 #define MYNEWT_VAL_BLE_HOST (1)
 #endif
 
+/* Overridden by targets/cc2564x (defined by @apache-mynewt-nimble/nimble/host) */
+#ifndef MYNEWT_VAL_BLE_HOST_RPA_RESOLVER
+#define MYNEWT_VAL_BLE_HOST_RPA_RESOLVER (1)
+#endif
+
 /* Overridden by app (defined by @apache-mynewt-nimble/nimble/host) */
 #ifndef MYNEWT_VAL_BLE_HS_AUTO_START
 #define MYNEWT_VAL_BLE_HS_AUTO_START (0)
@@ -783,12 +791,14 @@
 #define MYNEWT_VAL_BLE_HS_FLOW_CTRL_ITVL (1000)
 #endif
 
+/* Overridden by targets/cc2564x (defined by @apache-mynewt-nimble/nimble/host) */
 #ifndef MYNEWT_VAL_BLE_HS_FLOW_CTRL_THRESH
-#define MYNEWT_VAL_BLE_HS_FLOW_CTRL_THRESH (2)
+#define MYNEWT_VAL_BLE_HS_FLOW_CTRL_THRESH (5)
 #endif
 
+/* Overridden by targets/cc2564x (defined by @apache-mynewt-nimble/nimble/host) */
 #ifndef MYNEWT_VAL_BLE_HS_FLOW_CTRL_TX_ON_DISCONNECT
-#define MYNEWT_VAL_BLE_HS_FLOW_CTRL_TX_ON_DISCONNECT (0)
+#define MYNEWT_VAL_BLE_HS_FLOW_CTRL_TX_ON_DISCONNECT (1)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_HS_GAP_UNHANDLED_HCI_EVENT
@@ -871,10 +881,6 @@
 #define MYNEWT_VAL_BLE_RPA_TIMEOUT (300)
 #endif
 
-#ifndef MYNEWT_VAL_BLE_HOST_RPA_RESOLVER
-#define MYNEWT_VAL_BLE_HOST_RPA_RESOLVER (1)
-#endif
-
 /* Overridden by app (defined by @apache-mynewt-nimble/nimble/host) */
 #ifndef MYNEWT_VAL_BLE_SM_BONDING
 #define MYNEWT_VAL_BLE_SM_BONDING (1)
@@ -884,14 +890,16 @@
 #define MYNEWT_VAL_BLE_SM_CSIS_SIRK (0)
 #endif
 
+/* Overridden by targets/cc2564x (defined by @apache-mynewt-nimble/nimble/host) */
 #ifndef MYNEWT_VAL_BLE_SM_IO_CAP
-#define MYNEWT_VAL_BLE_SM_IO_CAP (BLE_HS_IO_NO_INPUT_OUTPUT)
+#define MYNEWT_VAL_BLE_SM_IO_CAP (BLE_HS_IO_DISPLAY_YESNO)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_SM_KEYPRESS
 #define MYNEWT_VAL_BLE_SM_KEYPRESS (0)
 #endif
 
+/* Overridden by targets/cc2564x (defined by @apache-mynewt-nimble/nimble/host) */
 #ifndef MYNEWT_VAL_BLE_SM_LEGACY
 #define MYNEWT_VAL_BLE_SM_LEGACY (1)
 #endif
@@ -1120,18 +1128,19 @@
 #define MYNEWT_VAL_BLE_TRANSPORT (1)
 #endif
 
+/* Overridden by targets/cc2564x (defined by @apache-mynewt-nimble/nimble/transport) */
 #ifndef MYNEWT_VAL_BLE_TRANSPORT_ACL_COUNT
-#define MYNEWT_VAL_BLE_TRANSPORT_ACL_COUNT (10)
+#define MYNEWT_VAL_BLE_TRANSPORT_ACL_COUNT (20)
 #endif
 
 /* Value copied from BLE_TRANSPORT_ACL_COUNT */
 #ifndef MYNEWT_VAL_BLE_TRANSPORT_ACL_FROM_HS_COUNT
-#define MYNEWT_VAL_BLE_TRANSPORT_ACL_FROM_HS_COUNT (10)
+#define MYNEWT_VAL_BLE_TRANSPORT_ACL_FROM_HS_COUNT (20)
 #endif
 
-/* Value copied from BLE_TRANSPORT_ACL_COUNT */
+/* Overridden by targets/cc2564x (defined by @apache-mynewt-nimble/nimble/transport) */
 #ifndef MYNEWT_VAL_BLE_TRANSPORT_ACL_FROM_LL_COUNT
-#define MYNEWT_VAL_BLE_TRANSPORT_ACL_FROM_LL_COUNT (10)
+#define MYNEWT_VAL_BLE_TRANSPORT_ACL_FROM_LL_COUNT (20)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_TRANSPORT_ACL_SIZE

--- a/third_party/nimble/syscfg/targets/cc2564x/syscfg.yml
+++ b/third_party/nimble/syscfg/targets/cc2564x/syscfg.yml
@@ -22,3 +22,15 @@ syscfg.vals:
 
     # Seems to be necessary to get AMS to connect without crashing.
     BLE_GATT_MAX_PROCS: 8
+    
+    # If we do not turn on flow control, large volumes of NOTIFY events
+    # (ANCS, etc) will cause us to crash.
+    BLE_HW_FLOW_CTRL: 1
+    BLE_HS_FLOW_CTRL_THRESH: 5
+    BLE_HS_FLOW_CTRL_TX_ON_DISCONNECT: 1
+    BLE_TRANSPORT_ACL_COUNT: 20
+    BLE_TRANSPORT_ACL_FROM_LL_COUNT: 20
+
+    # CC2564B does not support LE-SC or MITM (and enabling them wedges a phone until you reboot!).
+    BLE_SM_IO_CAP: 'BLE_HS_IO_DISPLAY_YESNO'
+    BLE_SM_LEGACY: 1


### PR DESCRIPTION
Enables flow control for HCI, and makes as surgical of restructuring of the interrupt handler as possible such that deallocation happens on the high-priority NimBLE UART thread, rather than on the main thread.

Fixes #245 (I hope).  With this fix, I spent most of an evening banging on it trying to get it to blow up, without tripping it at all (though last night I did see it regularly, which makes me think I must have forgotten to recompile before I flashed my device, or something).  Without this fix, I crash within two connection attempts with the `HCI_H4_ACL buf alloc` fault.