### PR TITLE
libutil: fix incorrect usage of rand()

### DIFF
--- a/src/libutil/platform.c
+++ b/src/libutil/platform.c
@@ -45,5 +45,5 @@ WEAK NORETURN util_assertion_failed(const char *filename, int line) {
 }
 
 WEAK uint32_t rand32(void) {
-  return ((uint32_t)rand() << 1) + (uint32_t)rand;
+  return ((uint32_t)rand() << 1) + (uint32_t)rand();
 }


### PR DESCRIPTION
Avoids build failures with:

```
../src/libutil/platform.c:48:36: error: cast to smaller integer type 'uint32_t' (aka 'unsigned int') from 'int (*)(void)' [-Werror,-Wpointer-to-int-cast]
   48 |   return ((uint32_t)rand() << 1) + (uint32_t)rand;
      |                                    ^~~~~~~~~~~~~~
1 error generated.
```

on gcc 13.2.1.