### PR TITLE
bluetooth-fw/nimble_store: pretend to persist CCCDs

### DIFF
--- a/src/bluetooth-fw/nimble/nimble_store.c
+++ b/src/bluetooth-fw/nimble/nimble_store.c
@@ -268,6 +268,9 @@ static int prv_nimble_store_write(int obj_type, const union ble_store_value *val
     case BLE_STORE_OBJ_TYPE_OUR_SEC:
     case BLE_STORE_OBJ_TYPE_PEER_SEC:
       return prv_nimble_store_write_sec(obj_type, &val->sec);
+    case BLE_STORE_OBJ_TYPE_CCCD:
+      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "prv_nimble_store_write is faking it for a CCCD!");
+      return 0;
     default:
       return BLE_HS_ENOTSUP;
   }
@@ -278,6 +281,9 @@ static int prv_nimble_store_delete(int obj_type, const union ble_store_key *key)
     case BLE_STORE_OBJ_TYPE_OUR_SEC:
     case BLE_STORE_OBJ_TYPE_PEER_SEC:
       return prv_nimble_store_delete_sec(obj_type, &key->sec);
+    case BLE_STORE_OBJ_TYPE_CCCD:
+      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "prv_nimble_store_delete is faking it for a CCCD!");
+      return 0;
     default:
       return BLE_HS_ENOTSUP;
   }


### PR DESCRIPTION
On iOS, on the *second* connection attempt to a cc256x device from the legacy app, the PPoG session will never wake up; we'll see an attempted write to the GATT Service Changed CCCD, but we'll respond with an "Insufficient Authorization (0x08)".  What on earth?  Nobody even references BLE_ATT_ERR_INSUFFICIENT_AUTHOR!  But, it turns out, 0x08 is shared with BLE_HS_ENOTSUP, and we *can* end up returning that from the nimble_store code by way of `ble_gatts_clt_cfg_access` -- and this only happens on the *second* time, because, according to `ble_gatts_clt_cfg_access_locked`, "Successful writes get persisted for bonded connections.".  When this happens, unrelated things go wrong later (like PPoG, for some reason).

Well, we cheat: we don't actually persist it, since our store is not complex enough to persist it to.  But nobody cares, so it's OK.

Fixes #260.