### PR TITLE
do not choke on gap_bondings of the wrong version

### DIFF
--- a/platform/platform_capabilities.py
+++ b/platform/platform_capabilities.py
@@ -56,6 +56,7 @@ master_capability_set = {
     'USE_PARALLEL_FLASH',
     'HAS_PUTBYTES_PREACKING',
     'HAS_FLASH_OTP',
+    'WAS_BLUETOPIA',
 }
 
 board_capability_dicts = [
@@ -66,6 +67,7 @@ board_capability_dicts = [
             'HAS_APPLE_MFI',
             'HAS_DEFECTIVE_FW_CRC',
             'HAS_MAGNETOMETER',
+            'WAS_BLUETOPIA',
         },
     },
     {
@@ -76,6 +78,7 @@ board_capability_dicts = [
             'HAS_DEFECTIVE_FW_CRC',
             'HAS_LED',
             'HAS_MAGNETOMETER',
+            'WAS_BLUETOPIA',
         },
     },
     {
@@ -102,6 +105,7 @@ board_capability_dicts = [
             'HAS_VIBE_SCORES',
             'USE_PARALLEL_FLASH',
             'HAS_WEATHER',
+            'WAS_BLUETOPIA',
         },
     },
     {
@@ -129,6 +133,7 @@ board_capability_dicts = [
             'HAS_VIBE_SCORES',
             'USE_PARALLEL_FLASH',
             'HAS_WEATHER',
+            'WAS_BLUETOPIA',
         },
     },
     {
@@ -154,6 +159,7 @@ board_capability_dicts = [
             'HAS_VIBE_SCORES',
             'USE_PARALLEL_FLASH',
             'HAS_WEATHER',
+            'WAS_BLUETOPIA',
         },
     },
     {
@@ -179,6 +185,7 @@ board_capability_dicts = [
             'HAS_VIBE_SCORES',
             'USE_PARALLEL_FLASH',
             'HAS_WEATHER',
+            'WAS_BLUETOPIA',
         },
     },
     {

--- a/src/fw/services/normal/bluetooth/bluetooth_persistent_storage.c
+++ b/src/fw/services/normal/bluetooth/bluetooth_persistent_storage.c
@@ -88,7 +88,14 @@ typedef struct PACKED {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //! Settings File
 
-#define BT_PERSISTENT_STORAGE_FILE_NAME "gap_bonding_db"
+#if CAPABILITY_WAS_BLUETOPIA
+  // Avoid making a mess with unreadable pairing names if someone downgrades
+  // to a Bluetopia firmware -- we'll just store our bondings in an entirely
+  // different database.
+  #define BT_PERSISTENT_STORAGE_FILE_NAME "gap_bonding_db_v2"
+#else
+  #define BT_PERSISTENT_STORAGE_FILE_NAME "gap_bonding_db"
+#endif
 #define BT_PERSISTENT_STORAGE_FILE_SIZE (4096)
 
 //! All of the actual pairings use a BTBondingID as a key. This is because with BLE pairings an


### PR DESCRIPTION
snowy uses v1 of bluetooth_persistent_storage, which NimBLE does not support.  As it turns out, we are generally not very robust against gap_bondings that we don't know how to deal with, and we can crash the system if they happen!  Let's rather ignore them, in case a future PebbleOS version extends the gap_bonding structure in a way that we don't know how to read and someone tries to downgrade.

And just like we choked on gap_bonding_dbs from formerly-Bluetopia devices, formerly-Bluetopia devices may behave very strangely indeed on ours.  On those devices, rename the bonding DB so it's not a problem.

Fixes https://github.com/pebble-dev/pebble-firmware/issues/253.