### PR TITLE
docs: add copy button to codeblocks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ release = "0.1.0"
 extensions = [
     "myst_parser",
     "sphinx_design",
+    "sphinx_copybutton",
 ]
 
 exclude_patterns = ["_build", "legacy", "Thumbs.db", ".DS_Store"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx~=8.2
 myst-parser~=4.0
 sphinx-book-theme~=1.1
 sphinx-design~=0.6
+sphinx-copybutton~=0.5.2


### PR DESCRIPTION
small pr to add a copy button for the codeblocks in the docs
<img width="880" height="170" alt="screenshot_20250815_20-02-17" src="https://github.com/user-attachments/assets/30aa1814-e4be-4473-87e5-ac2f2d5cb6a0" />
