### PR TITLE
Notifications: Add hard-coded colors for Discord and Beeper on iOS

### DIFF
--- a/src/fw/services/normal/notifications/ancs/ancs_known_apps.h
+++ b/src/fw/services/normal/notifications/ancs/ancs_known_apps.h
@@ -65,6 +65,8 @@
     APP("com.apple.mobileslideshow", TIMELINE_RESOURCE_NOTIFICATION_IOS_PHOTOS, GColorBlueMoonARGB8),
     APP("com.linkedin.LinkedIn", TIMELINE_RESOURCE_NOTIFICATION_LINKEDIN, GColorCobaltBlueARGB8),
     APP("com.tinyspeck.chatlyio", TIMELINE_RESOURCE_NOTIFICATION_SLACK, GColorFollyARGB8),
+    APP("com.automattic.beeper", TIMELINE_RESOURCE_GENERIC_SMS, GColorVividVioletARGB8), // icon resource can be replaced with bespoke Beeper icon from https://github.com/pebble-dev/iconography
+    APP("com.hammerandchisel.discord", TIMELINE_RESOURCE_GENERIC_SMS, GColorIndigoARGB8), // icon resource can be replaced with bespoke Discord icon from https://github.com/pebble-dev/iconography
 #endif
 
 #undef APP


### PR DESCRIPTION
Adds `com.hammerandchisel.discord` and `com.automattic.beeper` to the list of known ANCS apps. Beeper uses GColorVividViolet, and Discord uses GColorIndigo. The same change for Android will need to be done on the mobile app/libpebble3 side (https://github.com/coredevices/libpebble3/pull/27). 

This PR does *not* add icon resources for these apps, it only defines colors for their notifications.