### PR TITLE
Replace CONTRIBUTING.md with the "standard Rebble contributing guide"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Signed-off-by: Your Name <your.email@example.com>
 
 For your commits, replace:
 
-- `Your Name` with your legal name (pseudonyms, hacker handles, and the
+- `Your Name` with your real name (pseudonyms, hacker handles, and the
   names of groups are not allowed)
 
 - `your.email@example.com` with the same email address you are using to


### PR DESCRIPTION
The CONTRIBUTING.md file in other Rebble repositories (example: https://github.com/pebble-dev/developer.rebble.io/blob/main/CONTRIBUTING.md ) includes the change of "legal name" to "real name" in order to allow individuals who may not typically go by their legal name to contribute. 

The commit message in https://github.com/pebble-dev/developer.rebble.io/ calls this change the "standard Rebble contributing guide" and after discussion in the Discord, this change was intended to be applied to this repository as well, but was forgotten. 