### PR TITLE
bluetooth: change IO type for snowy back to one that allows connection

### DIFF
--- a/third_party/nimble/port/include/cc2564x/syscfg/syscfg.h
+++ b/third_party/nimble/port/include/cc2564x/syscfg/syscfg.h
@@ -893,7 +893,7 @@
 
 /* Overridden by targets/cc2564x (defined by @apache-mynewt-nimble/nimble/host) */
 #ifndef MYNEWT_VAL_BLE_SM_IO_CAP
-#define MYNEWT_VAL_BLE_SM_IO_CAP (BLE_HS_IO_DISPLAY_YESNO)
+#define MYNEWT_VAL_BLE_SM_IO_CAP (BLE_HS_IO_NO_INPUT_OUTPUT)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_SM_KEYPRESS

--- a/third_party/nimble/syscfg/targets/cc2564x/syscfg.yml
+++ b/third_party/nimble/syscfg/targets/cc2564x/syscfg.yml
@@ -21,5 +21,5 @@ syscfg.vals:
     BLE_TRANSPORT_ACL_FROM_LL_COUNT: 20
 
     # CC2564B does not support LE-SC or MITM (and enabling them wedges a phone until you reboot!).
-    BLE_SM_IO_CAP: 'BLE_HS_IO_DISPLAY_YESNO'
+    BLE_SM_IO_CAP: 'BLE_HS_IO_NO_INPUT_OUTPUT'
     BLE_SM_LEGACY: 1


### PR DESCRIPTION
So I'm finding again that the way this is set I cannot pair at all on Android (Pixel 10). I vaguely recall something about yes/no pairing being somehow associated with LE-SC but might be wrong?