### PR TITLE
MenuLayer: scroll wrap around and vibes

### DIFF
--- a/src/fw/applib/ui/menu_layer.h
+++ b/src/fw/applib/ui/menu_layer.h
@@ -338,6 +338,12 @@ enum {
 _Static_assert(MenuLayerColor_Count == 2, "Bad enum MenuLayerColor");
 #endif
 
+enum {
+  MenuLayerNoRepeatScrolling = 0,
+  MenuLayerRepeatScrollingUp = 1,
+  MenuLayerRepeatScrollingDown = 2,
+};
+
 //! Data structure of a MenuLayer.
 //! @note a `MenuLayer *` can safely be casted to a `Layer *` and
 //! `ScrollLayer *` and can thus be used with all other functions that take a
@@ -359,6 +365,8 @@ typedef struct MenuLayer {
     //! @internal
     //! Cell index + geometry cache of a cell that was in frame during the last redraw
     MenuCellSpan cursor;
+
+    uint8_t button_repeat_scrolling:2;
   } cache;
   //! @internal
   //! Selected cell index + geometery cache of the selected cell
@@ -401,10 +409,24 @@ typedef struct MenuLayer {
   //! independent of the scrolling animation.
   bool selection_animation_disabled:1;
 
+  //! If true, the MenuLayer will be able to wrap around the first element and the last element
+  //! when scrolling.
+  bool scroll_wrap_around:1;
+
+  //! If this is true alongside \ref scroll_wrap_around, the MenuLayer will be able to wrap around
+  //! even when the 'up' or 'down' button is held down. 
+  bool scroll_force_wrap_on_repeat:1;
+
+  //! If True, a vibration will occur when wrapping around.
+  bool scroll_vibe_on_wrap_around:1;
+
+  //! If True, a vibration will occur when cursor is getting blocked at the top or bottom
+  bool scroll_vibe_on_blocked:1;
+
   //! Add some padding to keep track of the \ref MenuLayer size budget.
   //! As long as the size stays within this budget, 2.x apps can safely use the 3.x MenuLayer type.
   //! When padding is removed, the assertion below should also be removed.
-  uint8_t padding[44];
+  uint8_t padding[40];
 } MenuLayer;
 
 //! Padding used below the last item in pixels
@@ -612,6 +634,42 @@ bool menu_layer_get_center_focused(MenuLayer *menu_layer);
 //! @see \ref menu_layer_get_center_focused
 void menu_layer_set_center_focused(MenuLayer *menu_layer, bool center_focused);
 
+//! True, if the \ref MenuLayer can wrap around the first and last element.
+//! @see \ref menu_layer_set_scroll_wrap_around
+bool menu_layer_get_scroll_wrap_around(MenuLayer *menu_layer);
+
+//! Controls if the \ref MenuLayer can wrap around from the first element to the last when going 
+//! up and from the last element to the first when going down.
+//! Even enabled, wrap around will stay disabled when holding down the navigation buttons (up or down).
+//! Defaults to false for every platform
+//! @param menu_layer The menu layer for which to enable or disable the behavior.
+//! @param scroll_wrap_around true = enable the wrap around, false = disable it.
+//! @see \ref menu_layer_get_scroll_wrap_around
+void menu_layer_set_scroll_wrap_around(MenuLayer *menu_layer, bool scroll_wrap_around);
+
+//! Return a number depending on scroll vibe behavior :
+//! - 0 : no vibe will occur
+//! - 1 : vibe will occur on wrap around
+//! - 2 : vibe will occur when stuck at the top or bottom of the menu
+//! @see \ref menu_layer_set_scroll_vibe_on_wrap
+//! @see \ref menu_layer_set_scroll_vibe_on_blocked
+uint8_t menu_layer_get_scroll_vibe_behavior(MenuLayer *menu_layer);
+
+//! Controls if the \ref MenuLayer wil generate a vibe when wrapping around.
+//! Defaults to false for every platform
+//! @param menu_layer The menu layer for which to enable or disable the behavior.
+//! @param scroll_vibe_on_wrap true = enable the vibe on wrap around, false = disable it.
+//! @see \ref menu_layer_get_scroll_vibe_behavior
+//! @see \ref menu_layer_set_scroll_vibe_on_blocked
+void menu_layer_set_scroll_vibe_on_wrap(MenuLayer *menu_layer, bool scroll_vibe_on_wrap);
+
+//! Controls if the \ref MenuLayer wil generate a vibe when blocked at the top or bottom.
+//! Defaults to false for every platform
+//! @param menu_layer The menu layer for which to enable or disable the behavior.
+//! @param scroll_vibe_on_wrap true = enable the vibe on cursor block, false = disable it.
+//! @see \ref menu_layer_get_scroll_vibe_behavior
+//! @see \ref menu_layer_set_scroll_vibe_on_wrap
+void menu_layer_set_scroll_vibe_on_blocked(MenuLayer *menu_layer, bool scroll_vibe_on_blocked);
 
 //!     @} // end addtogroup MenuLayer
 //!   @} // end addtogroup Layer

--- a/src/fw/apps/system_apps/alarms/alarm_editor.c
+++ b/src/fw/apps/system_apps/alarms/alarm_editor.c
@@ -259,6 +259,15 @@ static void prv_setup_day_picker_window(AlarmEditorData *data) {
                                   ALARMS_APP_HIGHLIGHT_COLOR,
                                   GColorWhite);
   menu_layer_set_click_config_onto_window(&data->day_picker_menu_layer, &data->day_picker_window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(&data->day_picker_menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(&data->day_picker_menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(&data->day_picker_menu_layer, true);
+#endif
   layer_add_child(&data->day_picker_window.layer,
                   menu_layer_get_layer(&data->day_picker_menu_layer));
   if (!alarm_get_kind(data->alarm_id, &data->alarm_kind)) {
@@ -414,6 +423,15 @@ static void prv_setup_custom_day_picker_window(AlarmEditorData *data) {
                                   GColorWhite);
   menu_layer_set_click_config_onto_window(&data->custom_day_picker_menu_layer,
                                           &data->custom_day_picker_window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(&data->custom_day_picker_menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(&data->custom_day_picker_menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(&data->custom_day_picker_menu_layer, true);
+#endif
   layer_add_child(&data->custom_day_picker_window.layer,
                   menu_layer_get_layer(&data->custom_day_picker_menu_layer));
   gbitmap_init_with_resource(&data->selected_icon, RESOURCE_ID_CHECKBOX_ICON_CHECKED);

--- a/src/fw/apps/system_apps/alarms/alarms.c
+++ b/src/fw/apps/system_apps/alarms/alarms.c
@@ -402,6 +402,15 @@ static void prv_handle_init(void) {
 
   menu_layer_set_highlight_colors(&data->menu_layer, ALARMS_APP_HIGHLIGHT_COLOR, GColorWhite);
   menu_layer_set_click_config_onto_window(&data->menu_layer, &data->window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(&data->menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(&data->menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(&data->menu_layer, true);
+#endif
   layer_add_child(&data->window.layer, menu_layer_get_layer(&data->menu_layer));
 
   status_bar_layer_init(&data->status_layer);

--- a/src/fw/apps/system_apps/health/health_detail_card.c
+++ b/src/fw/apps/system_apps/health/health_detail_card.c
@@ -391,6 +391,15 @@ HealthDetailCard *health_detail_card_create(const HealthDetailCardConfig *config
   menu_layer_set_normal_colors(menu_layer, detail_card->bg_color, GColorWhite);
   menu_layer_set_highlight_colors(menu_layer, detail_card->bg_color, GColorBlack);
   menu_layer_set_click_config_onto_window(menu_layer, &detail_card->window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(menu_layer, true);
+#endif
   layer_add_child(&detail_card->window.layer, menu_layer_get_layer(menu_layer));
 
   // setup content indicators

--- a/src/fw/apps/system_apps/launcher/default/launcher_menu_layer.c
+++ b/src/fw/apps/system_apps/launcher/default/launcher_menu_layer.c
@@ -202,6 +202,15 @@ void launcher_menu_layer_init(LauncherMenuLayer *launcher_menu_layer,
     .get_cell_height = prv_menu_layer_get_cell_height,
     .selection_will_change = prv_menu_layer_selection_will_change,
   });
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(menu_layer, true);
+#endif
 
   // Only setup the content indicator on round
 #if PBL_ROUND

--- a/src/fw/apps/system_apps/notifications_app.c
+++ b/src/fw/apps/system_apps/notifications_app.c
@@ -701,6 +701,15 @@ static void prv_window_load(Window *window) {
                                   GColorWhite);
 
   menu_layer_set_click_config_onto_window(menu_layer, window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(menu_layer, true);
+#endif
   layer_add_child(&window->layer, menu_layer_get_layer(menu_layer));
 
   TextLayer *text_layer = &data->text_layer;

--- a/src/fw/apps/system_apps/send_text/send_text.c
+++ b/src/fw/apps/system_apps/send_text/send_text.c
@@ -325,6 +325,15 @@ static void prv_init(void) {
 
     menu_layer_set_highlight_colors(&data->menu_layer, SEND_TEXT_APP_HIGHLIGHT_COLOR, GColorWhite);
     menu_layer_set_click_config_onto_window(&data->menu_layer, &data->window);
+#if FW_APPS_MENUS_WRAP
+    menu_layer_set_scroll_wrap_around(&data->menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(&data->menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(&data->menu_layer, true);
+#endif
     layer_add_child(&data->window.layer, menu_layer_get_layer(&data->menu_layer));
 
     StatusBarLayer *status_layer = &data->status_layer;

--- a/src/fw/apps/system_apps/settings/settings.c
+++ b/src/fw/apps/system_apps/settings/settings.c
@@ -92,6 +92,15 @@ static void prv_window_load(Window *window) {
                                   shell_prefs_get_settings_menu_highlight_color(),
                                   GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(menu_layer, true);
+#endif
 
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));
 }

--- a/src/fw/apps/system_apps/settings/settings_system.c
+++ b/src/fw/apps/system_apps/settings/settings_system.c
@@ -305,6 +305,15 @@ static void prv_information_window_load(Window *window) {
   });
   menu_layer_set_highlight_colors(menu_layer, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(menu_layer, true);
+#endif
 
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));
 }
@@ -723,6 +732,15 @@ static void prv_debugging_window_load(Window *window) {
   });
   menu_layer_set_highlight_colors(menu_layer, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(menu_layer, true);
+#endif
 
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));
 }
@@ -1169,6 +1187,15 @@ static void prv_certification_window_load(Window *window) {
   });
   menu_layer_set_highlight_colors(menu_layer, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(menu_layer, true);
+#endif
 
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));
 }

--- a/src/fw/apps/system_apps/settings/settings_window.c
+++ b/src/fw/apps/system_apps/settings/settings_window.c
@@ -182,6 +182,15 @@ static void prv_settings_window_load(Window *window) {
   menu_layer_set_normal_colors(menu_layer, GColorWhite, GColorBlack);
   menu_layer_set_highlight_colors(menu_layer, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(menu_layer, true);
+#endif
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));
 
   SettingsCallbacks *callbacks = prv_get_current_callbacks(data);

--- a/src/fw/apps/system_apps/watchfaces.c
+++ b/src/fw/apps/system_apps/watchfaces.c
@@ -154,6 +154,15 @@ static void prv_window_load(Window *window) {
                                   PBL_IF_COLOR_ELSE(GColorJazzberryJam, GColorBlack),
                                   GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(menu_layer, true);
+#endif
   layer_add_child(&window->layer, menu_layer_get_layer(menu_layer));
 }
 

--- a/src/fw/apps/system_apps/workout/workout_selection.c
+++ b/src/fw/apps/system_apps/workout/workout_selection.c
@@ -180,6 +180,15 @@ WorkoutSelectionWindow *workout_selection_push(SelectWorkoutCallback select_work
                                   PBL_IF_COLOR_ELSE(GColorYellow, GColorBlack),
                                   PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));
   menu_layer_set_click_config_onto_window(menu_layer, &selection_window->window);
+#if FW_APPS_MENUS_WRAP
+  menu_layer_set_scroll_wrap_around(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_WRAP
+  menu_layer_set_scroll_vibe_on_wrap(menu_layer, true);
+#endif
+#if FW_APPS_MENUS_VIBE_ON_BLOCKED
+  menu_layer_set_scroll_vibe_on_blocked(menu_layer, true);
+#endif
   layer_add_child(&selection_window->window.layer, menu_layer_get_layer(menu_layer));
 
   app_window_stack_push(&selection_window->window, true);

--- a/wscript
+++ b/wscript
@@ -219,6 +219,11 @@ def options(opt):
     opt.add_option('--reboot_on_bt_crash', action='store_true', help='Forces a BT '
                    'chip crash to immediately force a system reboot instead of just cycling airplane mode. '
                    'This makes it easier for us to actually get crash info')
+    opt.add_option('--enable-menu-wrap', action='store_true', help='Enable the scroll wrap around behavior on firmware apps menus')
+    opt.add_option('--enable-menu-vibe-on-blocked', action='store_true', help=
+                   'Enable the vibe behavior when blocked at the top or bottom menu item on firmware apps menus.'
+                   'If enabled, this setting will override the \'--enable-menu-vibe-on-wrap\' and set it to false.')
+    opt.add_option('--enable-menu-vibe-on-wrap', action='store_true', help='Enable the vibe behavior when wrapping around on firmware apps menus')
 
 
 def handle_configure_options(conf):
@@ -384,6 +389,16 @@ def handle_configure_options(conf):
 
     if not conf.options.no_pulse_everywhere:
         conf.env.append_value('DEFINES', 'PULSE_EVERYWHERE=1')
+    
+    if conf.options.enable_menu_wrap:
+        print("Enabling wrapping behavior of MenuLayer in firmware apps")
+        conf.env.append_value('DEFINES', 'FW_APPS_MENUS_WRAP')
+    if conf.options.enable_menu_vibe_on_blocked:
+        print("Enabling vibe on blocked behavior of MenuLayer in firmware apps")
+        conf.env.append_value('DEFINES', 'FW_APPS_MENUS_VIBE_ON_BLOCKED')
+    elif conf.options.enable_menu_vibe_on_wrap:
+        print("Enabling vibe on wrap around behavior of MenuLayer in firmware apps")
+        conf.env.append_value('DEFINES', 'FW_APPS_MENUS_VIBE_ON_WRAP')
 
 def _create_cm0_env(conf):
     prev_env = conf.env


### PR DESCRIPTION
Original PR --> https://github.com/coredevices/PebbleOS/pull/637

This PR adds a scroll wrap around capability to the `MenuLayer` ui object, alongside some vibe functionalities.

https://github.com/user-attachments/assets/89f6ddad-ab90-4c5d-8b58-78cda4a9a180

## New behaviors
### Scroll wrap-around
Pressing the 'up' button when the first element of the `MenuLayer` is selected will wrap around and bring the cursor to the last element.
Pressing the 'down' button when the last element of the `MenuLayer` is selected will wrap around and bring the cursor to the first element.
However, wrap around will not be applied when holding down the 'up' or 'down' button, and cursor will still lock on the first or last element.

This wrap-around functionality is disabled by default but can be enabled with the `menu_layer_set_scroll_wrap_around` function.

### Vibe on cursor blocked / vibe on wrap-around
A small 50ms vibe can be activated on wrap-around, or when blocked. Those two behaviors are mutually exclusive (setting one to true will set the other to false).

Those are also disabled by default, but can be enabled using the `menu_layer_set_vibe_on_wrap` and `menu_layer_set_vibe_on_blocked` functions.

## Compile options
This PR also implements some new compile options to enable those new capabilties on every `MenuLayer` used accross the firmware system apps.
- `--enable-menu-wrap`: Enable the scroll wrap around behavior on firmware apps menus
- `--enable-menu-vibe-on-blocked`: Enable the vibe behavior when blocked at the top or bottom menu item on firmware apps menus. If enabled, this setting will override the `--enable-menu-vibe-on-wrap` and set it to false.
- `--enable-menu-vibe-on-wrap`: Enable the vibe behavior when wrapping around on firmware apps menus
<details>
<summary>Here is a list of the apps affected by those compile options</summary>

- notifications_app
- watchfaces
- alarm_editor
- alarms
- health_detail_card
- launcher_menu_layer
- send_text
- settings_system
- settings_window
- settings
- workout_selection
</details>

## Known bug(s)
- Scroll wrap-around: if holding down the 'up' button when cursor is at the 2nd element, wrap around will still be applied. Same when holding down the 'down' button when cursor is at the penultimate element.

## Related issue(s)
Fix #284 