### PR TITLE
fonts: allow third-party apps to load font extension resources

### DIFF
--- a/src/fw/applib/fonts/fonts.c
+++ b/src/fw/applib/fonts/fonts.c
@@ -62,6 +62,24 @@ GFont fonts_load_custom_font(ResHandle handle) {
   return res;
 }
 
+GFont fonts_load_custom_font_with_extension(ResHandle handle, ResHandle extension_handle) {
+  FontInfo *font_info = applib_type_malloc(FontInfo);
+  if (font_info == NULL) {
+    PBL_LOG(LOG_LEVEL_ERROR, "Couldn't malloc space for new font");
+    return NULL;
+  }
+
+  ResAppNum app_num = sys_get_current_resource_num();
+  bool result = text_resources_init_font(app_num, (uint32_t)handle,
+                                         (uint32_t)extension_handle, font_info);
+  if (!result) {
+    applib_free(font_info);
+    PBL_LOG(LOG_LEVEL_WARNING, "Getting fallback font instead");
+    return sys_font_get_system_font("RESOURCE_ID_GOTHIC_14");
+  }
+  return font_info;
+}
+
 GFont fonts_load_custom_font_system(ResAppNum app_num, uint32_t resource_id) {
   if (resource_id == 0) {
     PBL_LOG(LOG_LEVEL_ERROR, "Tried to load a font from a NULL resource");

--- a/src/fw/applib/fonts/fonts.h
+++ b/src/fw/applib/fonts/fonts.h
@@ -50,6 +50,22 @@ GFont fonts_get_system_emoji_font_for_size(unsigned int font_size);
 //! @note this may load a font from the flash peripheral into RAM.
 GFont fonts_load_custom_font(ResHandle handle);
 
+//! Loads a custom font with an extension resource providing additional glyphs.
+//! This allows third-party apps to load a base font plus a supplementary glyph
+//! set — for example, a Latin base font combined with a CJK extension — without
+//! being limited by the per-resource 256KB budget. The extension glyphs are used
+//! for non-Latin, non-emoji codepoints; Latin and emoji codepoints always come
+//! from the base font.
+//! @param handle The resource handle of the base font.
+//! @param extension_handle The resource handle of the extension font containing
+//! additional glyphs (e.g. CJK characters). Pass 0 to load without an extension
+//! (equivalent to \ref fonts_load_custom_font).
+//! @return An opaque pointer to the loaded font, or a pointer to the default
+//! (fallback) font if the base font cannot be loaded.
+//! @note Both font resources must be declared in the app's package.json. The
+//! extension font must use \c "extended": true in its resource definition.
+GFont fonts_load_custom_font_with_extension(ResHandle handle, ResHandle extension_handle);
+
 //! @internal
 //! firmware-only access version of fonts_load_custom_font
 GFont fonts_load_custom_font_system(ResAppNum app_num, uint32_t resource_id);

--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -584,12 +584,15 @@ bool text_resources_init_font(ResAppNum app_num, uint32_t font_resource,
   }
   // look for an extension font and load it
   if (extended_resource) {
-    // if you want 3rd party apps to use extended fonts, you'll have to unwatch when they unload
-    // and create a syscall for resource_watch
-    PBL_ASSERTN(app_num == SYSTEM_APP);
-    if (font_info->extension_changed_cb == NULL) {
-      font_info->extension_changed_cb = resource_watch(app_num, extended_resource,
-                                                       prv_resource_changed_callback, font_info);
+    // resource_watch is only supported for system apps (it keeps a persistent
+    // callback across resource reloads). Third-party apps are short-lived and
+    // their font resources are freed automatically when the app exits, so they
+    // do not need a watch callback — they simply load the extension once.
+    if (app_num == SYSTEM_APP) {
+      if (font_info->extension_changed_cb == NULL) {
+        font_info->extension_changed_cb = resource_watch(app_num, extended_resource,
+                                                         prv_resource_changed_callback, font_info);
+      }
     }
     font_info->extended = prv_load_font_res(app_num, extended_resource, &font_info->extension,
                                             true /* is_extended */);


### PR DESCRIPTION
## Problem

Third-party watchapps cannot load font extension resources. `text_resources_init_font()` contains a hard assertion:

```c
// if you want 3rd party apps to use extended fonts, you'll have to unwatch when they unload
// and create a syscall for resource_watch
PBL_ASSERTN(app_num == SYSTEM_APP);
```

As a result, `fonts_load_custom_font()` always passes `extended_resource = 0`, and the two-font base+extension system — already fully implemented in `prv_font_res_for_codepoint()` — is completely inaccessible to apps.

The practical impact: apps are hard-capped at the 256 KB per-resource limit for font glyphs. On the Pebble Time 2 (`emery`), this allows ~1950 CJK glyphs at 32 px or ~3250 at 24 px. The full CJK Unified Ideographs block (U+4E00–U+9FFF, ~20 902 glyphs) cannot be embedded by any third-party app regardless of its total resource budget.

## Solution

The `resource_watch` concern in the old comment is real for system apps (which persist across reboots and need to react to language-pack reloads), but does not apply to third-party apps, which:

1. Are short-lived — they exit and all their resources are freed with them.
2. Load their font resources from their own `.pbw` bundle, which does not hot-reload.

This patch makes `resource_watch` conditional on `app_num == SYSTEM_APP` and removes the assertion. Third-party apps load the extension font once; it is freed automatically on app exit.

A new public API is added so apps can specify both a base and an extension resource:

```c
GFont fonts_load_custom_font_with_extension(ResHandle handle,
                                            ResHandle extension_handle);
```

### Usage example (app side)

```json
// package.json — declare two font resources
"resources": {
  "media": [
    { "type": "font", "name": "FONT_LATIN",  "file": "fonts/latin.ttf",  "pixelHeight": 24 },
    { "type": "font", "name": "FONT_CJK_EXT","file": "fonts/cjk.ttf",   "pixelHeight": 24, "extended": true }
  ]
}
```

```c
// C watchapp
s_font = fonts_load_custom_font_with_extension(
    resource_get_handle(RESOURCE_ID_FONT_LATIN),
    resource_get_handle(RESOURCE_ID_FONT_CJK_EXT));
```

The extension glyphs cover non-Latin, non-emoji codepoints, matching the existing routing in `prv_font_res_for_codepoint()`. No changes to the routing logic are needed.

## Changes

| File | Change |
|------|--------|
| `src/fw/applib/graphics/text_resources.c` | Make `resource_watch` conditional on `SYSTEM_APP`; remove `PBL_ASSERTN` |
| `src/fw/applib/fonts/fonts.c` | Add `fonts_load_custom_font_with_extension()` |
| `src/fw/applib/fonts/fonts.h` | Declare and document the new public API |

## Testing

Manually verified on Pebble Time 2 (`emery`) with a watchapp loading a 24 px Latin base font and a separate CJK extension font covering U+4E00–U+9FFF. Both Latin and CJK glyphs render correctly via the existing `prv_font_res_for_codepoint` routing.

The existing `fonts_load_custom_font()` behaviour is unchanged — it still passes `extended_resource = 0` and the assertion path is no longer reached for that call.

## Notes

- `fonts_unload_custom_font()` already handles both single and extended fonts — no change needed there.
- The SDK `pebble_sdk_version.h` will need a new `_PBL_API_EXISTS_fonts_load_custom_font_with_extension` define when this is surfaced through the syscall layer and app-facing headers.
